### PR TITLE
Change PY2020 to Resurgence in several places

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "PY2020: Hindsight"
+PROJECT_NAME           = "Resurgence (PY2022)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -44,7 +44,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Codebase for the Husky Robotics 2020 rover Hindsight"
+PROJECT_BRIEF          = "Codebase for the Husky Robotics 2021-2022 rover Resurgence"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/src/Networking/CANUtils.cpp
+++ b/src/Networking/CANUtils.cpp
@@ -37,12 +37,12 @@ void InitializeCANSocket() {
 	if (ioctl(can_fd, SIOCGIFINDEX, &can_ifr) < 0) {
 		perror("Failed to get hardware CAN interface index\n"
 			   "You can enable CAN with\n\n"
-			   "  ~/PY2020/enable_CAN_and_GPS.sh\n\n");
+			   "  ~/Resurgence/enable_CAN_and_GPS.sh\n\n");
 		strcpy(can_ifr.ifr_name, "vcan0");
 		if (ioctl(can_fd, SIOCGIFINDEX, &can_ifr) < 0) {
 			error("Failed to get virtual CAN interface index\n"
 				  "You can enable CAN with\n\n"
-				  "  ~/PY2020/enable_CAN_and_GPS.sh\n\n");
+				  "  ~/Resurgence/enable_CAN_and_GPS.sh\n\n");
 		}
 		log(LOG_INFO, "Found virtual CAN interface index.\n");
 	}


### PR DESCRIPTION
Since this repo is now named Resurgence we probably should change the name wherever it occurs internally.