### PR TITLE
changed world_interface.h to use new DataPoint class, added header guard

### DIFF
--- a/src/gps/read_usb_gps.cpp
+++ b/src/gps/read_usb_gps.cpp
@@ -48,7 +48,7 @@ point_t gpsToMeters(double lon, double lat) {
 	return r;
 }
 
-transform_t readGPS() {
+DataPoint<transform_t> readGPS() {
 	transform_t tf;
 	gps_mutex.lock();
 	if (fresh_data) {

--- a/src/world_interface/noop_world.cpp
+++ b/src/world_interface/noop_world.cpp
@@ -9,15 +9,15 @@ double setCmdVel(double /*dtheta*/, double /*dx*/) {
 	return 1.0;
 }
 
-points_t readLidarScan() {
-	return {};
+DataPoint<points_t> readLidarScan() {
+	return points_t{};
 }
 
-points_t readLandmarks() {
-	return {};
+DataPoint<points_t> readLandmarks() {
+	return points_t{};
 }
 
-transform_t readGPS() {
+DataPoint<transform_t> readGPS() {
 	return toTransform({0, 0, 0});
 }
 
@@ -25,7 +25,7 @@ point_t gpsToMeters(double lon, double lat) {
 	return {lon, lat, 1.0};
 }
 
-transform_t readOdom() {
+DataPoint<transform_t> readOdom() {
 	return toTransform({0, 0, 0});
 }
 

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -126,19 +126,19 @@ double setCmdVel(double dtheta, double dx) {
 	return scale_down_factor;
 }
 
-points_t readLandmarks() {
+DataPoint<points_t> readLandmarks() {
 	return AR::readLandmarks();
 }
 
-points_t readLidarScan() {
+DataPoint<points_t> readLidarScan() {
 	if (lidar::isLidarDataFresh()) {
 		return lidar::readLidar();
 	} else {
-		return {};
+		return points_t{};
 	}
 }
 
-transform_t readOdom() {
+DataPoint<transform_t> readOdom() {
 	struct timeval now;
 	gettimeofday(&now, NULL);
 	return getOdomAt(now);

--- a/src/world_interface/simulator_world.cpp
+++ b/src/world_interface/simulator_world.cpp
@@ -18,15 +18,15 @@ double setCmdVel(double dtheta, double dx) {
 	return 1.0;
 }
 
-points_t readLidarScan() {
+DataPoint<points_t> readLidarScan() {
 	return world.readLidar();
 }
 
-points_t readLandmarks() {
+DataPoint<points_t> readLandmarks() {
 	return world.readLandmarks();
 }
 
-transform_t readGPS() {
+DataPoint<transform_t> readGPS() {
 	return world.readGPS();
 }
 
@@ -34,7 +34,7 @@ point_t gpsToMeters(double lon, double lat) {
 	return {lon, lat, 1.0};
 }
 
-transform_t readOdom() {
+DataPoint<transform_t> readOdom() {
 	return world.readOdom();
 }
 

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -1,16 +1,94 @@
+#pragma once
 
 #include "../simulator/utils.h"
 
-void world_interface_init(); // Call this before trying to do anything else
+#include <chrono>
+
+// the clock used for time measurements for data
+using dataclock = std::chrono::steady_clock;
+// a point in time as measured by dataclock
+using datatime_t = std::chrono::time_point<dataclock>;
+
+/**
+ * @brief Represents data measured using a sensor at a given time.
+ *
+ * @tparam T The type of data measured from the sensor. Requires defined default constructor.
+ */
+template <typename T> class DataPoint {
+public:
+    /**
+     * @brief Construct an invalid DataPoint, holding no data
+     */
+    DataPoint() : valid(false), time(), data() {}
+
+	/**
+	 * @brief Construct a new DataPoint object, measured now.
+	 *
+	 * @param data The piece of data
+	 */
+	DataPoint(T data) : DataPoint(dataclock::now(), data) {}
+
+	/**
+	 * @brief Construct a new DataPoint object, measured at the given time.
+	 *
+	 * @param time The time at which the data was measured.
+	 * @param data The piece of data.
+	 */
+	DataPoint(datatime_t time, T data) : valid(true), time(time), data(data) {}
+
+	// provide an implicit conversion to the data type. Helps with backwards compatability.
+	operator T() const { return data; }
+
+    // check if this object holds any data
+    operator bool() const { return valid; }
+
+    /**
+     * @brief Check if this measurement was taken recently.
+     * 
+     * @param duration The data is fresh if it was taken at most this many milliseconds ago.
+     * @return true if the data was measured at most \p duration milliseconds ago, false otherwise.
+     */
+    bool isFresh(std::chrono::milliseconds duration) {
+        return dataclock::now() - duration <= time;
+    }
+
+    // true iff this measurement is valid, false otherwise.
+    bool valid; 
+	// the time at which the data was measured. Use only if valid == true.
+	datatime_t time;
+	// the measurement data. Use only if valid == true.
+	T data;
+};
+
+// Call this before trying to do anything else
+void world_interface_init();
 
 // If the requested dtheta/dx is too fast for the robot to execute, it will
 // scale them down and return the corresponding scale factor.
+// TODO: indicate what the return value of setCmdVel() means
 double setCmdVel(double dtheta, double dx);
 
-points_t readLidarScan();
-points_t readLandmarks();
-transform_t readGPS();
-transform_t readOdom();
+// read measurement from the lidar
+DataPoint<points_t> readLidarScan();
+
+/**
+ * @brief Read measurement from the CV system. As of now, returns a vector of fixed length, one
+ * for each post in the competition.
+ *
+ * @return DataPoint<points_t> A vector of fixed lengths. Non-visible markers are denoted with {0,0,0}, while all
+ * nonzero points are visible marker. The index of a landmark in this vector is its id.
+ */
+DataPoint<points_t> readLandmarks();
+
+// Get the current transform in the global frame based on a GPS measurement.
+// Note that these values are NOT lat/long.
+// TODO: figure out differential correction and adjust API accordingly
+DataPoint<transform_t> readGPS();
+
+// Calculates the current transform in the global frame based purely on forward kinematics
+DataPoint<transform_t> readOdom();
+
+// Given the current longitude and latitude, convert to a point_t position representation
 point_t gpsToMeters(double lon, double lat);
 
 // `index` must be in the range 0-6 (the URC competition will have 7 legs)

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -16,10 +16,10 @@ using datatime_t = std::chrono::time_point<dataclock>;
  */
 template <typename T> class DataPoint {
 public:
-    /**
-     * @brief Construct an invalid DataPoint, holding no data
-     */
-    DataPoint() : valid(false), time(), data() {}
+	/**
+	 * @brief Construct an invalid DataPoint, holding no data
+	 */
+	DataPoint() : valid(false), time(), data() {}
 
 	/**
 	 * @brief Construct a new DataPoint object, measured now.
@@ -39,21 +39,32 @@ public:
 	// provide an implicit conversion to the data type. Helps with backwards compatability.
 	operator T() const { return data; }
 
-    // check if this object holds any data
-    operator bool() const { return valid; }
+	// Check if this measurement is valid
+	operator bool() const { return valid; }
 
-    /**
-     * @brief Check if this measurement was taken recently.
-     * 
-     * @param duration The data is fresh if it was taken at most this many milliseconds ago.
-     * @return true if the data was measured at most \p duration milliseconds ago, false otherwise.
-     */
-    bool isFresh(std::chrono::milliseconds duration) {
-        return dataclock::now() - duration <= time;
-    }
+	/**
+	 * @brief Check if this measurement was taken recently.
+	 *
+	 * @param duration The data is fresh if it was taken at most this many milliseconds ago.
+	 * @return true if the data is valid and was measured at most \p duration milliseconds ago,
+	 * false otherwise.
+	 */
+	bool isFresh(std::chrono::milliseconds duration) {
+		return valid && dataclock::now() - duration <= time;
+	}
 
-    // true iff this measurement is valid, false otherwise.
-    bool valid; 
+	// Check if this measurement is valid
+	bool isValid() { return valid; }
+
+	// The time at which the data was measured. Use only if data is valid.
+	datatime_t getTime() { return time; }
+
+	// The measurement data. Use only if data is valid.
+	T getData() { return data; }
+
+private:
+	// true iff this measurement is valid, false otherwise.
+	bool valid;
 	// the time at which the data was measured. Use only if valid == true.
 	datatime_t time;
 	// the measurement data. Use only if valid == true.
@@ -75,8 +86,9 @@ DataPoint<points_t> readLidarScan();
  * @brief Read measurement from the CV system. As of now, returns a vector of fixed length, one
  * for each post in the competition.
  *
- * @return DataPoint<points_t> A vector of fixed lengths. Non-visible markers are denoted with {0,0,0}, while all
- * nonzero points are visible marker. The index of a landmark in this vector is its id.
+ * @return DataPoint<points_t> A vector of fixed lengths. Non-visible markers are denoted with
+ * {0,0,0}, while all nonzero points are visible marker. The index of a landmark in this vector
+ * is its id.
  */
 DataPoint<points_t> readLandmarks();
 


### PR DESCRIPTION
Related to [this task](https://app.clickup.com/t/1mzuhpw) on ClickUp.

No world_interface methods have been added or removed yet, this simply refactors existing methods to use the newly added `DataPoint` class, which provides utility for checking data freshness, representing an invalid measurement, etc. Additionally, documentation has been added to the methods in `world_interface.h`.

To check if data is new, we just have to save the old timestamp and compare against the current one. Additionally, we can also see how old the data is by checking `dataclock::now() - dataPoint.time`.

Additionally, I added a header guard, as well as standardizing time measurement utilities. Now, to measure time, we can just use `dataclock::now()`, which returns a `datatime_t`.