### PR TITLE
Clang-Format: Allow short functions to be on one line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ ColumnLimit: 95
 UseTab: Always
 BreakBeforeBraces: Attach
 AllowShortIfStatementsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
+AllowShortFunctionsOnASingleLine: true
 AccessModifierOffset: -4
 IncludeBlocks: Regroup
 IncludeCategories:


### PR DESCRIPTION
Edit the clang format file to allow short functions to be on a single line