### PR TITLE
Add methods to world_interface

### DIFF
--- a/src/Networking/motor_interface.cpp
+++ b/src/Networking/motor_interface.cpp
@@ -125,19 +125,11 @@ bool setOperationMode(const std::string& motor, int ik_axis, const std::string& 
 }
 
 void sendPWMPacket(const std::string& motor, double normalized_pwm) {
-	CANPacket p;
-	auto& scale_map = (normalized_pwm > 0 ? positive_arm_pwm_scales : negative_arm_pwm_scales);
-	double pwm = normalized_pwm * scale_map.at(motor);
-	int motor_serial = getIndex(motor_group, motor);
-	AssemblePWMDirSetPacket(&p, DEVICE_GROUP_MOTOR_CONTROL, motor_serial, pwm);
-	sendCANPacket(p);
+    setMotorPWM(motor, normalized_pwm);
 }
 
 void sendPIDPacket(const std::string& motor, int32_t pid_target) {
-	CANPacket p;
-	int motor_serial = getIndex(motor_group, motor);
-	AssemblePIDTargetSetPacket(&p, DEVICE_GROUP_MOTOR_CONTROL, motor_serial, pid_target);
-	sendCANPacket(p);
+	setMotorPos(motor, pid_target);
 }
 
 // TODO: if this sends the motor packet, should probably be called

--- a/src/world_interface/noop_world.cpp
+++ b/src/world_interface/noop_world.cpp
@@ -10,7 +10,7 @@ double setCmdVel(double /*dtheta*/, double /*dx*/) {
 }
 
 std::pair<double, double> getCmdVel() {
-    return {0, 0};
+	return {0, 0};
 }
 
 DataPoint<points_t> readLidarScan() {
@@ -26,7 +26,7 @@ DataPoint<transform_t> readGPS() {
 }
 
 DataPoint<pose_t> readVisualOdomVel() {
-    return DataPoint<pose_t>{};
+	return DataPoint<pose_t>{};
 }
 
 point_t gpsToMeters(double lon, double lat) {
@@ -41,6 +41,6 @@ URCLeg getLeg(int /*id*/) {
 	return URCLeg{-1, -1, {0., 0., 0.}};
 }
 
-void setMotorPWM(const std::string &motor, double normalizedPWM) {}
+void setMotorPWM(const std::string& motor, double normalizedPWM) {}
 
-void setMotorPos(const std::string &motor, int32_t targetPos) {}
+void setMotorPos(const std::string& motor, int32_t targetPos) {}

--- a/src/world_interface/noop_world.cpp
+++ b/src/world_interface/noop_world.cpp
@@ -44,3 +44,5 @@ URCLeg getLeg(int /*id*/) {
 void setMotorPWM(const std::string& motor, double normalizedPWM) {}
 
 void setMotorPos(const std::string& motor, int32_t targetPos) {}
+
+void setIndicator(indication_t signal) {}

--- a/src/world_interface/noop_world.cpp
+++ b/src/world_interface/noop_world.cpp
@@ -9,6 +9,10 @@ double setCmdVel(double /*dtheta*/, double /*dx*/) {
 	return 1.0;
 }
 
+std::pair<double, double> getCmdVel() {
+    return {0, 0};
+}
+
 DataPoint<points_t> readLidarScan() {
 	return points_t{};
 }
@@ -19,6 +23,10 @@ DataPoint<points_t> readLandmarks() {
 
 DataPoint<transform_t> readGPS() {
 	return toTransform({0, 0, 0});
+}
+
+DataPoint<pose_t> readVisualOdomVel() {
+    return DataPoint<pose_t>{};
 }
 
 point_t gpsToMeters(double lon, double lat) {
@@ -32,3 +40,7 @@ DataPoint<transform_t> readOdom() {
 URCLeg getLeg(int /*id*/) {
 	return URCLeg{-1, -1, {0., 0., 0.}};
 }
+
+void setMotorPWM(const std::string &motor, double normalizedPWM) {}
+
+void setMotorPos(const std::string &motor, int32_t targetPos) {}

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -192,3 +192,6 @@ void setMotorPos(const std::string& motor, int32_t targetPos) {
 	AssemblePIDTargetSetPacket(&p, DEVICE_GROUP_MOTOR_CONTROL, motor_serial, targetPos);
 	sendCANPacket(p);
 }
+
+// TODO: implement
+void setIndicator(indication_t signal) {}

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -2,6 +2,7 @@
 #include "../Networking/CANUtils.h"
 #include "../Networking/json.hpp"
 #include "../Networking/motor_interface.h"
+#include "../Networking/ParseCAN.h"
 #include "../Util.h"
 #include "../ar/read_landmarks.h"
 #include "../camera/Camera.h"
@@ -126,6 +127,10 @@ double setCmdVel(double dtheta, double dx) {
 	return scale_down_factor;
 }
 
+std::pair<double, double> getCmdVel() {
+    return {odom_dtheta_, odom_dx_};
+}
+
 DataPoint<points_t> readLandmarks() {
 	return AR::readLandmarks();
 }
@@ -144,6 +149,57 @@ DataPoint<transform_t> readOdom() {
 	return getOdomAt(now);
 }
 
+DataPoint<pose_t> readVisualOdomVel() {
+    return DataPoint<pose_t>{};
+}
+
 URCLeg getLeg(int index) {
 	return URCLeg{0, -1, {0., 0., 0.}};
+}
+
+const std::map<std::string, double> positive_arm_pwm_scales = {
+	{"arm_base",   12000},
+	{"shoulder",  -20000},
+	{"elbow",     -32768},
+	{"forearm",    -6000},
+	{"diffleft",    5000},
+	{"diffright",  -5000},
+	{"hand",       15000}};
+const std::map<std::string, double> negative_arm_pwm_scales = {
+	{"arm_base", 12000},
+	{"shoulder", -14000},
+	{"elbow", -18000},
+	{"forearm", -6000},
+	{"diffleft", 5000},
+	{"diffright", -10000},
+	{"hand", 15000}};
+const std::map<std::string, double> incremental_pid_scales = {
+	{"arm_base", M_PI / 8}, // TODO: Check signs
+	{"shoulder", -M_PI / 8},
+	{"elbow", -M_PI / 8},
+	{"forearm", 0}, // We haven't implemented PID on these motors yet
+	{"diffleft", 0},
+	{"diffright", 0},
+	{"hand", 0}};
+
+
+template <typename T> int getIndex(const std::vector<T> &vec, const T &val) {
+    auto itr = std::find(vec.begin(), vec.end(), val);
+    return itr == vec.end() ? -1 : itr - vec.begin();
+}
+
+void setMotorPWM(const std::string &motor, double normalizedPWM) {
+    CANPacket p;
+	auto& scale_map = (normalizedPWM > 0 ? positive_arm_pwm_scales : negative_arm_pwm_scales);
+	double pwm = normalizedPWM * scale_map.at(motor);
+	int motor_serial = getIndex(motor_group, motor);
+	AssemblePWMDirSetPacket(&p, DEVICE_GROUP_MOTOR_CONTROL, motor_serial, pwm);
+	sendCANPacket(p);
+}
+
+void setMotorPos(const std::string &motor, int32_t targetPos) {
+    CANPacket p;
+	int motor_serial = getIndex(motor_group, motor);
+	AssemblePIDTargetSetPacket(&p, DEVICE_GROUP_MOTOR_CONTROL, motor_serial, targetPos);
+	sendCANPacket(p);
 }

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -1,8 +1,8 @@
 #include "../Globals.h"
 #include "../Networking/CANUtils.h"
+#include "../Networking/ParseCAN.h"
 #include "../Networking/json.hpp"
 #include "../Networking/motor_interface.h"
-#include "../Networking/ParseCAN.h"
 #include "../Util.h"
 #include "../ar/read_landmarks.h"
 #include "../camera/Camera.h"
@@ -128,7 +128,7 @@ double setCmdVel(double dtheta, double dx) {
 }
 
 std::pair<double, double> getCmdVel() {
-    return {odom_dtheta_, odom_dx_};
+	return {odom_dtheta_, odom_dx_};
 }
 
 DataPoint<points_t> readLandmarks() {
@@ -150,7 +150,7 @@ DataPoint<transform_t> readOdom() {
 }
 
 DataPoint<pose_t> readVisualOdomVel() {
-    return DataPoint<pose_t>{};
+	return DataPoint<pose_t>{};
 }
 
 URCLeg getLeg(int index) {
@@ -158,21 +158,11 @@ URCLeg getLeg(int index) {
 }
 
 const std::map<std::string, double> positive_arm_pwm_scales = {
-	{"arm_base",   12000},
-	{"shoulder",  -20000},
-	{"elbow",     -32768},
-	{"forearm",    -6000},
-	{"diffleft",    5000},
-	{"diffright",  -5000},
-	{"hand",       15000}};
+	{"arm_base", 12000}, {"shoulder", -20000}, {"elbow", -32768}, {"forearm", -6000},
+	{"diffleft", 5000},	 {"diffright", -5000}, {"hand", 15000}};
 const std::map<std::string, double> negative_arm_pwm_scales = {
-	{"arm_base", 12000},
-	{"shoulder", -14000},
-	{"elbow", -18000},
-	{"forearm", -6000},
-	{"diffleft", 5000},
-	{"diffright", -10000},
-	{"hand", 15000}};
+	{"arm_base", 12000}, {"shoulder", -14000},	{"elbow", -18000}, {"forearm", -6000},
+	{"diffleft", 5000},	 {"diffright", -10000}, {"hand", 15000}};
 const std::map<std::string, double> incremental_pid_scales = {
 	{"arm_base", M_PI / 8}, // TODO: Check signs
 	{"shoulder", -M_PI / 8},
@@ -182,14 +172,13 @@ const std::map<std::string, double> incremental_pid_scales = {
 	{"diffright", 0},
 	{"hand", 0}};
 
-
-template <typename T> int getIndex(const std::vector<T> &vec, const T &val) {
-    auto itr = std::find(vec.begin(), vec.end(), val);
-    return itr == vec.end() ? -1 : itr - vec.begin();
+template <typename T> int getIndex(const std::vector<T>& vec, const T& val) {
+	auto itr = std::find(vec.begin(), vec.end(), val);
+	return itr == vec.end() ? -1 : itr - vec.begin();
 }
 
-void setMotorPWM(const std::string &motor, double normalizedPWM) {
-    CANPacket p;
+void setMotorPWM(const std::string& motor, double normalizedPWM) {
+	CANPacket p;
 	auto& scale_map = (normalizedPWM > 0 ? positive_arm_pwm_scales : negative_arm_pwm_scales);
 	double pwm = normalizedPWM * scale_map.at(motor);
 	int motor_serial = getIndex(motor_group, motor);
@@ -197,8 +186,8 @@ void setMotorPWM(const std::string &motor, double normalizedPWM) {
 	sendCANPacket(p);
 }
 
-void setMotorPos(const std::string &motor, int32_t targetPos) {
-    CANPacket p;
+void setMotorPos(const std::string& motor, int32_t targetPos) {
+	CANPacket p;
 	int motor_serial = getIndex(motor_group, motor);
 	AssemblePIDTargetSetPacket(&p, DEVICE_GROUP_MOTOR_CONTROL, motor_serial, targetPos);
 	sendCANPacket(p);

--- a/src/world_interface/simulator_world.cpp
+++ b/src/world_interface/simulator_world.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 World world;
+std::pair<double, double> cmdVel(0, 0);
 
 void world_interface_init() {
 	world.addURCObstacles();
@@ -15,7 +16,12 @@ void world_interface_init() {
 
 double setCmdVel(double dtheta, double dx) {
 	world.setCmdVel(dtheta, dx);
+    cmdVel = {dtheta, dx};
 	return 1.0;
+}
+
+std::pair<double, double> getCmdVel() {
+    return cmdVel;
 }
 
 DataPoint<points_t> readLidarScan() {
@@ -30,6 +36,10 @@ DataPoint<transform_t> readGPS() {
 	return world.readGPS();
 }
 
+DataPoint<pose_t> readVisualOdomVel() {
+    return DataPoint<pose_t>{};
+}
+
 point_t gpsToMeters(double lon, double lat) {
 	return {lon, lat, 1.0};
 }
@@ -41,3 +51,7 @@ DataPoint<transform_t> readOdom() {
 URCLeg getLeg(int index) {
 	return world.getLeg(index);
 }
+
+void setMotorPWM(const std::string &motor, double normalizedPWM) {}
+
+void setMotorPos(const std::string &motor, int32_t targetPos) {}

--- a/src/world_interface/simulator_world.cpp
+++ b/src/world_interface/simulator_world.cpp
@@ -1,6 +1,7 @@
 #include "../simulator/world.h"
 #include "world_interface.h"
 
+#include <iostream>
 #include <unistd.h>
 
 World world;
@@ -52,6 +53,14 @@ URCLeg getLeg(int index) {
 	return world.getLeg(index);
 }
 
+// not supported in 2D sim
 void setMotorPWM(const std::string& motor, double normalizedPWM) {}
 
+// not supported in 2D sim
 void setMotorPos(const std::string& motor, int32_t targetPos) {}
+
+void setIndicator(indication_t signal) {
+	std::string signals[] = {"off", "autonomous", "teleop", "arrivedAtDest"};
+	auto idx = static_cast<int>(signal);
+	std::cout << "Setting indicator: " << signals[idx] << std::endl;
+}

--- a/src/world_interface/simulator_world.cpp
+++ b/src/world_interface/simulator_world.cpp
@@ -16,12 +16,12 @@ void world_interface_init() {
 
 double setCmdVel(double dtheta, double dx) {
 	world.setCmdVel(dtheta, dx);
-    cmdVel = {dtheta, dx};
+	cmdVel = {dtheta, dx};
 	return 1.0;
 }
 
 std::pair<double, double> getCmdVel() {
-    return cmdVel;
+	return cmdVel;
 }
 
 DataPoint<points_t> readLidarScan() {
@@ -37,7 +37,7 @@ DataPoint<transform_t> readGPS() {
 }
 
 DataPoint<pose_t> readVisualOdomVel() {
-    return DataPoint<pose_t>{};
+	return DataPoint<pose_t>{};
 }
 
 point_t gpsToMeters(double lon, double lat) {
@@ -52,6 +52,6 @@ URCLeg getLeg(int index) {
 	return world.getLeg(index);
 }
 
-void setMotorPWM(const std::string &motor, double normalizedPWM) {}
+void setMotorPWM(const std::string& motor, double normalizedPWM) {}
 
-void setMotorPos(const std::string &motor, int32_t targetPos) {}
+void setMotorPos(const std::string& motor, int32_t targetPos) {}

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -9,6 +9,8 @@ using dataclock = std::chrono::steady_clock;
 // a point in time as measured by dataclock
 using datatime_t = std::chrono::time_point<dataclock>;
 
+enum class indication_t { off, autonomous, teleop, arrivedAtDest };
+
 /**
  * @brief Represents data measured using a sensor at a given time.
  *
@@ -120,6 +122,9 @@ point_t gpsToMeters(double lon, double lat);
 
 // `index` must be in the range 0-6 (the URC competition will have 7 legs)
 URCLeg getLeg(int index);
+
+// set the indicator to indicate the given signal. May no-op if indicator is not supported.
+void setIndicator(indication_t signal);
 
 /**
  * @brief Set the PWM command of the given motor.

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -79,6 +79,8 @@ void world_interface_init();
 // TODO: indicate what the return value of setCmdVel() means
 double setCmdVel(double dtheta, double dx);
 
+std::pair<double, double> getCmdVel();
+
 // read measurement from the lidar
 DataPoint<points_t> readLidarScan();
 
@@ -100,8 +102,27 @@ DataPoint<transform_t> readGPS();
 // Calculates the current transform in the global frame based purely on forward kinematics
 DataPoint<transform_t> readOdom();
 
+// Calculate the current pose velocity (in the robot's reference frame) using visual odometry.
+DataPoint<pose_t> readVisualOdomVel();
+
 // Given the current longitude and latitude, convert to a point_t position representation
 point_t gpsToMeters(double lon, double lat);
 
 // `index` must be in the range 0-6 (the URC competition will have 7 legs)
 URCLeg getLeg(int index);
+
+/**
+ * @brief Set the PWM command of the given motor.
+ * 
+ * @param motor The name of the motor. Must be a valid motor name.
+ * @param normalizedPWM The PWM command, in the range [-1, 1]
+ */
+void setMotorPWM(const std::string &motor, double normalizedPWM);
+
+/**
+ * @brief Set the target position of the motor.
+ * 
+ * @param motor The name of the motor. Must be a valid motor name.
+ * @param targetPos The target position. Refer to the specific motor for more information.
+ */
+void setMotorPos(const std::string &motor, int32_t targetPos);

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -37,10 +37,14 @@ public:
 	DataPoint(datatime_t time, T data) : valid(true), time(time), data(data) {}
 
 	// provide an implicit conversion to the data type. Helps with backwards compatability.
-	operator T() const { return data; }
+	operator T() const {
+		return data;
+	}
 
 	// Check if this measurement is valid
-	operator bool() const { return valid; }
+	operator bool() const {
+		return valid;
+	}
 
 	/**
 	 * @brief Check if this measurement was taken recently.
@@ -54,13 +58,19 @@ public:
 	}
 
 	// Check if this measurement is valid
-	bool isValid() { return valid; }
+	bool isValid() {
+		return valid;
+	}
 
 	// The time at which the data was measured. Use only if data is valid.
-	datatime_t getTime() { return time; }
+	datatime_t getTime() {
+		return time;
+	}
 
 	// The measurement data. Use only if data is valid.
-	T getData() { return data; }
+	T getData() {
+		return data;
+	}
 
 private:
 	// true iff this measurement is valid, false otherwise.
@@ -113,16 +123,16 @@ URCLeg getLeg(int index);
 
 /**
  * @brief Set the PWM command of the given motor.
- * 
+ *
  * @param motor The name of the motor. Must be a valid motor name.
  * @param normalizedPWM The PWM command, in the range [-1, 1]
  */
-void setMotorPWM(const std::string &motor, double normalizedPWM);
+void setMotorPWM(const std::string& motor, double normalizedPWM);
 
 /**
  * @brief Set the target position of the motor.
- * 
+ *
  * @param motor The name of the motor. Must be a valid motor name.
  * @param targetPos The target position. Refer to the specific motor for more information.
  */
-void setMotorPos(const std::string &motor, int32_t targetPos);
+void setMotorPos(const std::string& motor, int32_t targetPos);


### PR DESCRIPTION
Moved motor control methods from `motor_interface` to `world_interface`, since I think that makes more sense. Additionally, that allows code other than the networking code to control those motors.

Additionally, I added a `getCmdVel()` method, as well as a `readVisualOdomVel()` in anticipation of visual odometry.

Let me know if there are other things that should be added to `world_interface`, or if there's something else that I missed.