### PR TITLE
Change clang format to only allow empty functions on single line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ ColumnLimit: 95
 UseTab: Always
 BreakBeforeBraces: Attach
 AllowShortIfStatementsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
 AccessModifierOffset: -4
 IncludeBlocks: Regroup
 IncludeCategories:


### PR DESCRIPTION
I didn't realize in my last clang-format PR that setting `AllowShortFunctionsOnASingleLine: true` would make _all_ short functions be on a single line, which isn't ideal.

Setting it to `Empty` instead only makes empty functions be on a single line, which I think is better.

Sorry about the duplicate PR, I'm not super familiar with clang format. 