### PR TITLE
Set up cameras before initializing AR

### DIFF
--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -46,11 +46,11 @@ void setupCameras() {
 }
 
 void world_interface_init() {
+	setupCameras();
+
 	bool gps_success = gps::usb::startGPSThread();
 	bool lidar_success = lidar::initializeLidar();
 	bool landmark_success = AR::initializeLandmarkDetection();
-
-	setupCameras();
 
 	gettimeofday(&last_odom_reading_, NULL);
 	last_odom_tf_ = toTransform({0., 0., 0.});


### PR DESCRIPTION
Very minor fix, I just noticed that initializing AR before setting up the cameras would cause the setup to fail.

This fixes that by setting up the cameras first.