### PR TITLE
Separate logic of reading camera config from opening camera HW

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,6 +176,7 @@ add_library(real_world_interface STATIC
   lidar/read_hokuyo_lidar.cpp
   camera/Camera.cpp
   camera/CameraParams.cpp
+  camera/CameraConfig.cpp
   ar/Detector.cpp
   ar/MarkerSet.cpp
   ar/MarkerPattern.cpp

--- a/src/camera/Camera.h
+++ b/src/camera/Camera.h
@@ -280,30 +280,5 @@ public:
 	void setDescription(std::string new_description);
 };
 
-/**
-   Exception for errors in the camera configuration.
- */
-class invalid_camera_config : public std::exception {
-public:
-	/**
-	   Constructs an invalid_camera_config exception with the default message "Invalid camera
-	   configuration".
-	 */
-	invalid_camera_config();
-	/**
-	   Constructs an invalid_camera_config exception with the given message appended to
-	   "Invalid camera configuration:".
-	   @param msg The message to use for the exception.
-	 */
-	invalid_camera_config(const std::string& msg);
-	/**
-	   Returns the exception message as a C string.
-	 */
-	virtual const char* what() const noexcept;
-
-private:
-	std::string _msg;
-};
-
 /** @} */
 } // namespace cam

--- a/src/camera/CameraConfig.cpp
+++ b/src/camera/CameraConfig.cpp
@@ -42,7 +42,7 @@ const char* invalid_camera_config::what() const noexcept {
 	return _msg.c_str();
 }
 
-CameraConfig readConfigFromFile(std::string filename) {
+CameraConfig readConfigFromFile(const std::string& filename) {
 	cv::FileStorage fs(filename, cv::FileStorage::READ);
 	if (!fs.isOpened()) {
 		throw std::invalid_argument("Configuration file " + filename + " does not exist");

--- a/src/camera/CameraConfig.cpp
+++ b/src/camera/CameraConfig.cpp
@@ -1,0 +1,95 @@
+#include "CameraConfig.h"
+
+namespace cam {
+
+/**@{*/
+/**
+   Config file key for camera filename.
+ */
+const std::string KEY_FILENAME = "filename";
+/**
+   Config file key for camera id.
+ */
+const std::string KEY_CAMERA_ID = "camera_id";
+/**
+   Config file key for intrinsic parameters.
+ */
+const std::string KEY_INTRINSIC_PARAMS = "intrinsic_params";
+/**
+   Config file key for extrinsic parameters.
+ */
+const std::string KEY_EXTRINSIC_PARAMS = "extrinsic_params";
+/**
+   Config file key for calibration information.
+ */
+const std::string KEY_CALIB_INFO = "calib_info";
+/**
+   Config file key for camera name.
+ */
+const std::string KEY_NAME = "name";
+/**
+   Config file key for camera description.
+ */
+const std::string KEY_DESCRIPTION = "description";
+/**@}*/
+
+invalid_camera_config::invalid_camera_config() : _msg("Invalid camera configuration") {}
+
+invalid_camera_config::invalid_camera_config(const std::string& msg)
+	: _msg("Invalid camera configuration: " + msg) {}
+
+const char* invalid_camera_config::what() const noexcept {
+	return _msg.c_str();
+}
+
+CameraConfig readConfigFromFile(std::string filename) {
+	cv::FileStorage fs(filename, cv::FileStorage::READ);
+	if (!fs.isOpened()) {
+		throw std::invalid_argument("Configuration file " + filename + " does not exist");
+	}
+
+	CameraConfig cfg{};
+
+	// read intrinsic parameters
+	if (!fs[KEY_INTRINSIC_PARAMS].empty()) {
+		CameraParams intrinsics;
+		fs[KEY_INTRINSIC_PARAMS] >> intrinsics;
+		cfg.intrinsicParams = intrinsics;
+	}
+
+	// read extrinsic parameters
+	if (!fs[KEY_EXTRINSIC_PARAMS].empty()) {
+		cv::Mat extrinsics;
+		fs[KEY_EXTRINSIC_PARAMS] >> extrinsics;
+		cfg.extrinsicParams = extrinsics;
+	}
+
+	// read name
+	if (fs[KEY_NAME].empty()) {
+		throw invalid_camera_config(KEY_NAME + " must be present");
+	}
+	cfg.name = static_cast<std::string>(fs[KEY_NAME]);
+
+	// read description
+	if (!fs[KEY_DESCRIPTION].empty()) {
+		cfg.description = static_cast<std::string>(fs[KEY_DESCRIPTION]);
+	}
+
+	// read filename or camera ID, and open camera.
+	if (!fs[KEY_FILENAME].empty()) {
+		cfg.filename = static_cast<std::string>(fs[KEY_FILENAME]);
+	}
+
+	if (!fs[KEY_CAMERA_ID].empty()) {
+		cfg.cameraID = static_cast<int>(fs[KEY_CAMERA_ID]);
+	}
+
+	if (!cfg.filename && !cfg.cameraID) {
+		throw invalid_camera_config("One of " + KEY_FILENAME + " or " + KEY_CAMERA_ID +
+									" must be present");
+	}
+
+	return cfg;
+}
+
+} // namespace cam

--- a/src/camera/CameraConfig.h
+++ b/src/camera/CameraConfig.h
@@ -34,15 +34,48 @@ private:
 	std::string _msg;
 };
 
+/**
+ * @brief A struct that represents the information outlined in @ref cameraparams.
+ */
 struct CameraConfig {
+	/**
+	 * @brief The name of the camera.
+	 */
 	std::string name;
+	/**
+	 * @brief If specified, gives the intrinsic parameter matrix.
+	 */
 	std::optional<CameraParams> intrinsicParams;
+	/**
+	 * @brief If specified, gives the extrinsic parameter matrix.
+	 */
 	std::optional<cv::Mat> extrinsicParams;
+	/**
+	 * @brief If specified, gives the file to which the camera should be streamed.
+	 */
 	std::optional<std::string> filename;
+	/**
+	 * @brief If specified, gives the id of the camera.
+	 */
 	std::optional<int> cameraID;
+	/**
+	 * @brief If specified, gives the text description of the camera.
+	 */
 	std::optional<std::string> description;
 };
 
-CameraConfig readConfigFromFile(std::string filename);
+/**
+ * @brief Read the camera config from the specified file.
+ *
+ * @param filename The path to the configuration file to open and read. Configuration file
+ * should be formatted as described in @ref cameraconfig.
+ *
+ * @return CameraConfig The parsed camera config object.
+ *
+ * @throws invalid_camera_config If the configuration is invalid for any reason.
+ *
+ * @throws invalid_argument If the file does not exist.
+ */
+CameraConfig readConfigFromFile(const std::string& filename);
 
 } // namespace cam

--- a/src/camera/CameraConfig.h
+++ b/src/camera/CameraConfig.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "CameraParams.h"
+
+#include <optional>
+#include <string>
+
+#include <opencv2/core.hpp>
+
+namespace cam {
+
+/**
+Exception for errors in the camera configuration.
+*/
+class invalid_camera_config : public std::exception {
+public:
+	/**
+	   Constructs an invalid_camera_config exception with the default message "Invalid camera
+	   configuration".
+	 */
+	invalid_camera_config();
+	/**
+	   Constructs an invalid_camera_config exception with the given message appended to
+	   "Invalid camera configuration:".
+	   @param msg The message to use for the exception.
+	 */
+	invalid_camera_config(const std::string& msg);
+	/**
+	   Returns the exception message as a C string.
+	 */
+	virtual const char* what() const noexcept;
+
+private:
+	std::string _msg;
+};
+
+struct CameraConfig {
+	std::string name;
+	std::optional<CameraParams> intrinsicParams;
+	std::optional<cv::Mat> extrinsicParams;
+	std::optional<std::string> filename;
+	std::optional<int> cameraID;
+	std::optional<std::string> description;
+};
+
+CameraConfig readConfigFromFile(std::string filename);
+
+} // namespace cam


### PR DESCRIPTION
Reader the camera config previously couldn't be done without actually opening a hardware camera. This isn't ideal, particularly for the simulator.

This PR adds the `CameraConfig` struct which contains the information stored in a camera config YAML file, as well as a `readConfigFromFile()` method which reads the config from the file.