### PR TITLE
Fixed doxy comments for CameraConfig

### DIFF
--- a/src/camera/Camera.h
+++ b/src/camera/Camera.h
@@ -32,13 +32,6 @@ namespace cam {
  */
 
 /**
-	@name Configuration File Keys
-
-	The following are constants for the keys used in the camera configuration
-	files. See @ref cameraconfig for more details.
-*/
-
-/**
 	@brief Represents a camera on the rover, from which a video feed can be
 	retrieved.
 

--- a/src/camera/CameraConfig.h
+++ b/src/camera/CameraConfig.h
@@ -10,6 +10,17 @@
 
 namespace cam {
 
+/**
+   @addtogroup camera
+   @{
+ */
+
+/**
+	@name Configuration File Keys
+
+	The following are constants for the keys used in the camera configuration
+	files. See @ref cameraconfig for more details.
+*/
 /**@{*/
 /**
    Config file key for camera filename.
@@ -67,7 +78,7 @@ private:
 };
 
 /**
- * @brief A struct that represents the information outlined in @ref cameraparams.
+ * @brief A struct that represents the information outlined in @ref cameraconfig.
  */
 struct CameraConfig {
 	/**
@@ -112,5 +123,7 @@ struct CameraConfig {
  * @throws invalid_argument If the file does not exist.
  */
 CameraConfig readConfigFromFile(const std::string& filename);
+
+/** @} */
 
 } // namespace cam


### PR DESCRIPTION
This is a pretty minor PR.

I forgot to move over a doxy comment along with the camera config file constants before, so I fixed that now. Additionally, I added everything in `CameraConfig.h` to the `camera` group.