### PR TITLE
Minor bug fix to simulator setCmdVel()

### DIFF
--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -253,7 +253,7 @@ double setCmdVel(double dtheta, double dx) {
 	setMotorPWM("frontRightWheel", rPWM);
 	setMotorPWM("rearRightWheel", rPWM);
 
-	return maxAbsPWM > Constants::MAX_WHEEL_VEL ? maxAbsPWM : 1.0;
+	return maxAbsPWM > 1 ? maxAbsPWM : 1.0;
 }
 
 landmarks_t readLandmarks() {


### PR DESCRIPTION
The PWM is normalized, so it should be compared to 1, not to tangential speed, which is wrong anyway.