### PR TITLE
Don't block rover while waiting for gps fix

### DIFF
--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -34,9 +34,9 @@ constexpr std::array<const char*, 7> NAV_STATE_NAMES({"GPS", "POST_VISIBLE", "SE
 
 class Autonomous {
 public:
-	explicit Autonomous(const std::vector<navtypes::URCLeg>& urc_targets, double controlHz);
-	Autonomous(const std::vector<navtypes::URCLeg>& urc_targets, double controlHz,
-			   const navtypes::pose_t& startPose);
+	explicit Autonomous(const std::vector<navtypes::URCLegGPS>& gpsTargets, double controlHz);
+	Autonomous(double controlHz, const navtypes::pose_t& startPose);
+	void init();
 	// Returns a pair of floats, in heading, speed
 	// Accepts current heading of the robot as parameter
 	// Gets the target's coordinate
@@ -44,9 +44,11 @@ public:
 	void autonomyIter();
 
 private:
+	bool initialized;
 	std::vector<navtypes::URCLeg> urc_targets;
+	std::vector<navtypes::URCLegGPS> urc_targets_gps;
 	size_t leg_idx; // which of the urc_targets we're currently navigating toward
-	navtypes::pose_t search_target;
+	std::optional<navtypes::pose_t> search_target;
 	// Gate targets are {NAN, NAN, NAN} if unset and {INF, INF, INF} if reached
 	// gate_targets.second(2) is NAN if targets have not been refined with more accurate
 	// landmark measurements

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -134,8 +134,8 @@ void closeRover(int signum) {
 	raise(SIGTERM);
 }
 
-std::vector<URCLeg> parseGPSLegs(std::string filepath) {
-	std::vector<URCLeg> urc_legs;
+std::vector<URCLegGPS> parseGPSLegs(std::string filepath) {
+	std::vector<URCLegGPS> urc_legs;
 	std::ifstream gps_legs(filepath);
 
 	int left_post_id, right_post_id;
@@ -151,9 +151,9 @@ std::vector<URCLeg> parseGPSLegs(std::string filepath) {
 		std::istringstream line_stream(line);
 		if (line_stream >> left_post_id >> right_post_id >> lat >> lon) {
 			// we assume that gps already has a fix
-			point_t leg_map_space = gpsToMeters({lat, lon}).value();
-			URCLeg leg = {left_post_id, right_post_id, leg_map_space};
-			log(LOG_INFO, "Got urc leg at %f %f\n", leg_map_space(0), leg_map_space(1));
+			gpscoords_t gps = {lat, lon};
+			URCLegGPS leg = {left_post_id, right_post_id, gps};
+			log(LOG_INFO, "Got urc leg at lat=%f lon=%f\n", lat, lon);
 			urc_legs.push_back(leg);
 		}
 	}
@@ -162,10 +162,6 @@ std::vector<URCLeg> parseGPSLegs(std::string filepath) {
 	if (urc_legs.size() == 0) {
 		log(LOG_ERROR, "could not get URC legs\n");
 		exit(0);
-		// File does not exist or has no valid legs, use simulation legs as defaults
-		for (int i = 0; i < 7; i++) {
-			urc_legs.push_back(getLeg(i));
-		}
 	}
 
 	return urc_legs;
@@ -183,15 +179,9 @@ int rover_loop(int argc, char** argv) {
 	InitializeRover(MOTOR_UNIT_MODE_PWM, true);
 	CANPacket packet;
 
-	// wait for GPS to get fix
-	while (!gpsHasFix()) {
-		log(LOG_INFO, "Waiting for GPS fix...\n");
-		std::this_thread::sleep_for(std::chrono::milliseconds(500));
-	}
-
 	// Target locations for autonomous navigation
 	// Eventually this will be set by communication from the base station
-	std::vector<URCLeg> urc_legs = parseGPSLegs("../src/gps/simulator_legs.txt");
+	std::vector<URCLegGPS> urc_legs = parseGPSLegs("../src/gps/simulator_legs.txt");
 	Autonomous autonomous(urc_legs, CONTROL_HZ);
 	char buffer[MAXLINE];
 	auto roverStart = steady_clock::now();

--- a/src/gps/gps_util.h
+++ b/src/gps/gps_util.h
@@ -2,14 +2,6 @@
 
 #include "../navtypes.h"
 
-/** Represents a GPS coordinate in degrees. Positive is north/east. */
-struct gpscoords_t {
-	/** the latitude of the gps coordinate, in degrees */
-	double lat;
-	/** the longitude of the gps coordinate, in degrees */
-	double lon;
-};
-
 /**
  * @brief A GPS datum that specifies the reference ellipsoid for use in GPS calculations.
  * This is important to resolve what exact location a gps coordinate specifies.
@@ -56,13 +48,13 @@ public:
 	 * @param datum The datum to use for the GPS calculations.
 	 * @param origin The gps coordinates of the origin of the xy-plane.
 	 */
-	GPSToMetersConverter(const GPSDatum& datum, const gpscoords_t& origin);
+	GPSToMetersConverter(const GPSDatum& datum, const navtypes::gpscoords_t& origin);
 
 	/** convert the given gps coordinates to a coordinate on the xy plane, in meters */
-	navtypes::point_t gpsToMeters(const gpscoords_t& coords) const;
+	navtypes::point_t gpsToMeters(const navtypes::gpscoords_t& coords) const;
 
 	/** convert a coordinate on the xy-plane to a gps coordinate */
-	gpscoords_t metersToGPS(const navtypes::point_t& pos) const;
+	navtypes::gpscoords_t metersToGPS(const navtypes::point_t& pos) const;
 
 	/**
 	 * Get the number of meters per degree of latitude.
@@ -78,7 +70,7 @@ public:
 
 private:
 	const GPSDatum datum;
-	const gpscoords_t origin;
+	const navtypes::gpscoords_t origin;
 	double metersPerDegLat;
 	double metersPerDegLon;
 };

--- a/src/gps/usb_gps/read_usb_gps.cpp
+++ b/src/gps/usb_gps/read_usb_gps.cpp
@@ -1,6 +1,7 @@
 #include "read_usb_gps.h"
 
 #include "../../log.h"
+#include "../../navtypes.h"
 #include "../../world_interface/world_interface.h"
 #include "../gps_util.h"
 
@@ -15,15 +16,15 @@ gpsmm gps_rec("localhost", DEFAULT_GPSD_PORT);
 std::thread gps_thread;
 std::mutex gps_mutex;
 bool has_fix;
-gpscoords_t most_recent_coords;
+navtypes::gpscoords_t most_recent_coords;
 datatime_t gps_time;
 
 // implements method from world_interface.h
-DataPoint<gpscoords_t> readGPSCoords() {
-	DataPoint<gpscoords_t> data;
+DataPoint<navtypes::gpscoords_t> readGPSCoords() {
+	DataPoint<navtypes::gpscoords_t> data;
 	gps_mutex.lock();
 	if (gpsHasFix()) {
-		data = DataPoint<gpscoords_t>(gps_time, most_recent_coords);
+		data = DataPoint<navtypes::gpscoords_t>(gps_time, most_recent_coords);
 	}
 	gps_mutex.unlock();
 	return data;

--- a/src/navtypes.h
+++ b/src/navtypes.h
@@ -6,6 +6,14 @@
 
 namespace navtypes {
 
+/** Represents a GPS coordinate in degrees. Positive is north/east. */
+struct gpscoords_t {
+	/** the latitude of the gps coordinate, in degrees */
+	double lat;
+	/** the longitude of the gps coordinate, in degrees */
+	double lon;
+};
+
 /* Obstacles are specifed as a list of 2D vertices. Must be convex.
  * Do not repeat the starting vertex at the end. */
 using obstacle_t = Eigen::ArrayX2d;
@@ -25,6 +33,12 @@ struct URCLeg {
 	int left_post_id;
 	int right_post_id; // This will be -1 for legs that are just single posts
 	point_t approx_GPS;
+};
+
+struct URCLegGPS {
+	int left_post_id;
+	int right_post_id;
+	gpscoords_t gps;
 };
 
 } // namespace navtypes

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -96,7 +96,7 @@ namespace gps {
  * @return DataPoint<gpscoords_t> The last GPS coordinates measured by the sensor, or empty if
  * no fix.
  */
-DataPoint<gpscoords_t> readGPSCoords();
+DataPoint<navtypes::gpscoords_t> readGPSCoords();
 } // namespace gps
 
 /**
@@ -136,7 +136,7 @@ DataPoint<navtypes::pose_t> getTruePose();
  * @return std::optional<point_t> The transformed point, or an empty datapoint
  * if the GPS does not have a fix.
  */
-std::optional<navtypes::point_t> gpsToMeters(const gpscoords_t& coord);
+std::optional<navtypes::point_t> gpsToMeters(const navtypes::gpscoords_t& coord);
 
 // Calculates the current transform in the global frame based purely on forward kinematics
 DataPoint<navtypes::transform_t> readOdom();


### PR DESCRIPTION
Before, the rover would block during initialization while waiting for a fix. This is fine during the competition, but makes testing unwieldy.

Instead, the GPS coordinates of the map legs are lazily mapped to world space once the gps fix becomes available. Since the pose graph initialization required this too, the pose graph is lazily initialized too.

The robot will be automatically initialized by `autonomyIter()` when the gps fix becomes available.