### PR TITLE
Add a thread to repeat setJointPower to keep motors alive

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -17,25 +17,6 @@ constexpr double ELBOW_LENGTH = 0.7;	// placeholder(m)
  */
 constexpr float MDEG_PER_DEG = 1000;
 
-constexpr std::array<uint32_t, 6> arm_PPJRs = {
-	17 * 1000, // base, estimate
-
-	20 * 1000, // shoulder, estimate
-	36 * 1000, // elbow, rough estimate
-
-	360 * 1000, // forearm, unmeasured
-	360 * 1000, // diff_left, unmeasured
-	360 * 1000	// diff_right, unmeasured
-};
-
-// So far only the base, shoulder, elbow have been tuned
-//
-// base, shoulder, elbow, forearm, diff_left, diff_right
-constexpr std::array<int32_t, 6> arm_Ps = {1000, 100, 500, 0, 0, 0};
-constexpr std::array<int32_t, 6> arm_Is = {50, 0, 50, 0, 0, 0};
-constexpr std::array<int32_t, 6> arm_Ds = {10000, 1000, 10000, 0, 0, 0};
-constexpr std::array<uint8_t, 6> arm_encoder_signs = {0, 0, 1, 0, 0, 0};
-
 // TODO: tune these drive constants
 constexpr double ROBOT_LENGTH = 1.0;
 /**

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -3,6 +3,7 @@
 #include "kinematics/DiffDriveKinematics.h"
 #include "world_interface/data.h"
 
+#include <chrono>
 #include <cmath>
 #include <string>
 
@@ -102,6 +103,8 @@ constexpr const char* SIM_PROTOCOL_NAME = "/simulator";
    WebSocket server endpoint for the DGPS protocol.
  */
 constexpr const char* DGPS_PROTOCOL_NAME = "/dgps";
+
+constexpr std::chrono::milliseconds JOINT_POWER_REPEAT_PERIOD(333);
 
 namespace Nav {
 // Distance (m) we could have traveled forward in the time it takes to turn 1 radian

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -108,15 +108,15 @@ constexpr std::chrono::milliseconds JOINT_POWER_REPEAT_PERIOD(333);
 
 namespace Nav {
 // Distance (m) we could have traveled forward in the time it takes to turn 1 radian
-const double RADIAN_COST = EFF_WHEEL_BASE / 2.0;
+constexpr double RADIAN_COST = EFF_WHEEL_BASE / 2.0;
 // Planner stays this far away from obstacles (m)
-const double SAFE_RADIUS = Constants::ROBOT_LENGTH * 1.3;
-const int MAX_ITERS = 3000; // Max number of nodes expanded during A* search
-const double PLAN_RESOLUTION = Constants::ROBOT_LENGTH; // m
-const double SEARCH_RADIUS_INCREMENT = Constants::ROBOT_LENGTH * 3;
-const double GPS_WAYPOINT_RADIUS = Constants::ROBOT_LENGTH * 1.5;
-const double LANDMARK_WAYPOINT_RADIUS = Constants::ROBOT_LENGTH * 1.3;
-const double EPS = 2.0; // heuristic weight for weighted A*
+constexpr double SAFE_RADIUS = Constants::ROBOT_LENGTH * 1.3;
+constexpr int MAX_ITERS = 3000; // Max number of nodes expanded during A* search
+constexpr double PLAN_RESOLUTION = Constants::ROBOT_LENGTH; // m
+constexpr double SEARCH_RADIUS_INCREMENT = Constants::ROBOT_LENGTH * 3;
+constexpr double GPS_WAYPOINT_RADIUS = Constants::ROBOT_LENGTH * 1.5;
+constexpr double LANDMARK_WAYPOINT_RADIUS = Constants::ROBOT_LENGTH * 1.3;
+constexpr double EPS = 2.0; // heuristic weight for weighted A*
 } // namespace Nav
 
 // Lidar

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -95,6 +95,7 @@ void parseCommandLine(int argc, char** argv) {
 }
 
 int main(int argc, char** argv) {
+	// TODO: make it possible to set this from the command line
 	LOG_LEVEL = LOG_INFO;
 	Globals::AUTONOMOUS = false;
 	Globals::websocketServer.start();

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -136,4 +136,8 @@ uint64_t getUnixTime() {
 									 .count());
 }
 
+frozen::string freezeStr(const std::string& str) {
+	return frozen::string(str.c_str(), str.size());
+}
+
 } // namespace util

--- a/src/Util.h
+++ b/src/Util.h
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <string>
+#include <frozen/string.h>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -230,4 +231,8 @@ std::string to_string(const T& val) {
 	return std::to_string(val);
 }
 
+/**
+ * @brief Convert the given std::string to a frozen::string.
+ */
+frozen::string freezeStr(const std::string& str);
 } // namespace util

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -208,13 +208,15 @@ void MissionControlProtocol::handleConnection() {
 	this->_server.sendJSON(Constants::MC_PROTOCOL_NAME, j);
 
 	// start power repeat thread (if not already running)
-	{
-		std::unique_lock<std::mutex> power_repeat_lock(_joint_repeat_mutex);
-		if (!this->_joint_repeat_running) {
-			this->_joint_repeat_running = true;
-			this->_joint_repeat_thread =
-				std::thread(&MissionControlProtocol::jointPowerRepeatTask, this);
-		}
+	this->startPowerRepeat();
+}
+
+void MissionControlProtocol::startPowerRepeat() {
+	std::unique_lock<std::mutex> power_repeat_lock(_joint_repeat_mutex);
+	if (!this->_joint_repeat_running) {
+		this->_joint_repeat_running = true;
+		this->_joint_repeat_thread =
+			std::thread(&MissionControlProtocol::jointPowerRepeatTask, this);
 	}
 }
 

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -214,9 +214,10 @@ void MissionControlProtocol::handleConnection() {
 	json j = {{"type", MOUNTED_PERIPHERAL_REP_TYPE}, {"peripheral", "arm"}};
 	this->_server.sendJSON(Constants::MC_PROTOCOL_NAME, j);
 
-	// TODO: maybe don't do this if we are in autonomous mode
-	// start power repeat thread (if not already running)
-	this->startPowerRepeat();
+	if (!Globals::AUTONOMOUS) {
+		// start power repeat thread (if not already running)
+		this->startPowerRepeat();
+	}
 }
 
 void MissionControlProtocol::startPowerRepeat() {
@@ -233,7 +234,7 @@ void MissionControlProtocol::stopAndShutdownPowerRepeat() {
 	// unnecessarily if it isn't; this could be bad in the case where we receive a spurious
 	// operation mode request while already in autonomous and shut down all the motors)
 	std::unique_lock<std::mutex> power_repeat_lock(_joint_repeat_mutex);
-	if(this->_joint_repeat_running){
+	if (this->_joint_repeat_running) {
 		// Clear the last_joint_power map so the repeater thread won't do anything
 		std::lock_guard<std::mutex> joint_lock(this->_joint_power_mutex);
 		this->_last_joint_power.clear();

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -237,7 +237,7 @@ MissionControlProtocol::~MissionControlProtocol() {
 }
 
 void MissionControlProtocol::setRequestedJointPower(jointid_t joint, double power) {
-	std::unique_lock<std::shared_mutex> joint_lock(this->_joint_power_mutex);
+	std::lock_guard<std::mutex> joint_lock(this->_joint_power_mutex);
 	this->_last_joint_power[joint] = power;
 	robot::setJointPower(joint, power);
 }
@@ -246,7 +246,7 @@ void MissionControlProtocol::jointPowerRepeatTask() {
 	while (this->_joint_repeat_running) {
 		std::this_thread::sleep_for(Constants::JOINT_POWER_REPEAT_PERIOD);
 		{
-			std::shared_lock<std::shared_mutex> joint_lock(this->_joint_power_mutex);
+			std::lock_guard<std::mutex> joint_lock(this->_joint_power_mutex);
 			for (const auto& current_pair : this->_last_joint_power) {
 				if (!this->_joint_repeat_running) {
 					break;

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -2,6 +2,7 @@
 
 #include "../Constants.h"
 #include "../Globals.h"
+#include "../base64/base64_img.h"
 #include "../log.h"
 
 #include <functional>
@@ -10,8 +11,6 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
-
-#include "../base64/base64_img.h"
 
 namespace net {
 namespace mc {
@@ -152,7 +151,7 @@ static void handleJointPositionRequest(const json& j) {
 	double position_deg = j["position"];
 	int32_t position_mdeg = std::round(position_deg * 1000);
 	// TODO adapt this when we have the new CAN/motor interface;
-	//setMotorPos(motor, position_mdeg);
+	// setMotorPos(motor, position_mdeg);
 }
 
 static bool validateCameraStreamOpenRequest(const json& j) {
@@ -194,7 +193,8 @@ MissionControlProtocol::MissionControlProtocol(SingleClientWSServer& server)
 	: WebSocketProtocol(Constants::MC_PROTOCOL_NAME), _server(server), _open_streams(),
 	  _last_joint_power() {
 	// TODO: Add support for tank drive requests
-	// TODO: add support for science station requests (lazy susan, lazy susan lid, drill, syringe)
+	// TODO: add support for science station requests (lazy susan, lazy susan lid, drill,
+	// syringe)
 
 	this->addMessageHandler(EMERGENCY_STOP_REQ_TYPE, handleEmergencyStopRequest,
 							validateEmergencyStopRequest);

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -16,6 +16,7 @@ namespace mc {
 
 using json = nlohmann::json;
 using robot::types::CameraID;
+using robot::types::jointid_t;
 using websocket::SingleClientWSServer;
 using websocket::WebSocketProtocol;
 
@@ -29,15 +30,22 @@ public:
 
 private:
 	void videoStreamTask();
+	void jointPowerRepeatTask();
 	SingleClientWSServer& _server;
 	std::shared_mutex _stream_mutex;
+	std::shared_mutex _joint_power_mutex;
 	std::unordered_map<CameraID, uint32_t> _open_streams;
+	std::unordered_map<jointid_t, double> _last_joint_power;
 	std::atomic<bool> _streaming_running;
 	std::thread _streaming_thread;
+	std::atomic<bool> _joint_repeat_running;
+	std::thread _joint_repeat_thread;
 	void handleCameraStreamOpenRequest(const json& j);
 	void handleCameraStreamCloseRequest(const json& j);
+	void handleJointPowerRequest(const json& j);
 	void sendCameraStreamReport(const CameraID& cam, const std::string& b64_data);
 	void handleConnection();
+	void setRequestedJointPower(jointid_t joint, double power);
 };
 
 }; // namespace mc

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -34,12 +34,13 @@ private:
 	void jointPowerRepeatTask();
 	SingleClientWSServer& _server;
 	std::shared_mutex _stream_mutex;
-	// protects _last_joint_power
-	std::mutex _joint_power_mutex;
 	std::unordered_map<CameraID, uint32_t> _open_streams;
-	std::unordered_map<jointid_t, double> _last_joint_power;
 	std::atomic<bool> _streaming_running;
 	std::thread _streaming_thread;
+	// protects _last_joint_power, _last_cmd_vel
+	std::mutex _joint_power_mutex;
+	std::unordered_map<jointid_t, double> _last_joint_power;
+	std::pair<double, double> _last_cmd_vel;
 	// protects _joint_repeat_running and _joint_repeat_thread
 	std::mutex _joint_repeat_mutex;
 	bool _joint_repeat_running;
@@ -48,10 +49,12 @@ private:
 	void handleCameraStreamOpenRequest(const json& j);
 	void handleCameraStreamCloseRequest(const json& j);
 	void handleJointPowerRequest(const json& j);
+	void handleDriveRequest(const json& j);
 	void sendCameraStreamReport(const CameraID& cam, const std::string& b64_data);
 	void handleConnection();
 	void stopAndShutdownPowerRepeat();
 	void setRequestedJointPower(jointid_t joint, double power);
+	void setRequestedCmdVel(double dtheta, double dx);
 };
 
 }; // namespace mc

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -11,6 +11,7 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <optional>
 
 namespace net {
 namespace mc {
@@ -40,7 +41,8 @@ private:
 	// protects _last_joint_power, _last_cmd_vel
 	std::mutex _joint_power_mutex;
 	std::unordered_map<jointid_t, double> _last_joint_power;
-	std::pair<double, double> _last_cmd_vel;
+	// if not present, then there is no last requested drive power
+	std::optional<std::pair<double, double>> _last_cmd_vel;
 	// protects _joint_repeat_running and _joint_repeat_thread
 	std::mutex _joint_repeat_mutex;
 	bool _joint_repeat_running;

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -43,9 +43,11 @@ private:
 	std::unordered_map<jointid_t, double> _last_joint_power;
 	// if not present, then there is no last requested drive power
 	std::optional<std::pair<double, double>> _last_cmd_vel;
-	// protects _joint_repeat_running and _joint_repeat_thread
-	std::mutex _joint_repeat_mutex;
+	// protects _joint_repeat_running, ALWAYS lock before thread and joint_power_mutex
+	std::mutex _joint_repeat_running_mutex;
 	bool _joint_repeat_running;
+	// protects _joint_repeat_thread
+	std::mutex _joint_repeat_thread_mutex;
 	std::thread _joint_repeat_thread;
 	std::condition_variable _power_repeat_cv;
 	void handleEmergencyStopRequest(const json& j);

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -33,7 +33,7 @@ private:
 	void jointPowerRepeatTask();
 	SingleClientWSServer& _server;
 	std::shared_mutex _stream_mutex;
-	std::shared_mutex _joint_power_mutex;
+	std::mutex _joint_power_mutex;
 	std::unordered_map<CameraID, uint32_t> _open_streams;
 	std::unordered_map<jointid_t, double> _last_joint_power;
 	std::atomic<bool> _streaming_running;

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -5,6 +5,7 @@
 #include "../world_interface/world_interface.h"
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
 #include <shared_mutex>
 #include <thread>
@@ -33,13 +34,17 @@ private:
 	void jointPowerRepeatTask();
 	SingleClientWSServer& _server;
 	std::shared_mutex _stream_mutex;
+	// protects _last_joint_power
 	std::mutex _joint_power_mutex;
 	std::unordered_map<CameraID, uint32_t> _open_streams;
 	std::unordered_map<jointid_t, double> _last_joint_power;
 	std::atomic<bool> _streaming_running;
 	std::thread _streaming_thread;
-	std::atomic<bool> _joint_repeat_running;
+	// protects _joint_repeat_running and _joint_repeat_thread
+	std::mutex _joint_repeat_mutex;
+	bool _joint_repeat_running;
 	std::thread _joint_repeat_thread;
+	std::condition_variable _power_repeat_cv;
 	void handleCameraStreamOpenRequest(const json& j);
 	void handleCameraStreamCloseRequest(const json& j);
 	void handleJointPowerRequest(const json& j);

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -54,6 +54,7 @@ private:
 	void handleDriveRequest(const json& j);
 	void sendCameraStreamReport(const CameraID& cam, const std::string& b64_data);
 	void handleConnection();
+	void startPowerRepeat();
 	void stopAndShutdownPowerRepeat();
 	void setRequestedJointPower(jointid_t joint, double power);
 	void setRequestedCmdVel(double dtheta, double dx);

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -48,6 +48,8 @@ private:
 	bool _joint_repeat_running;
 	std::thread _joint_repeat_thread;
 	std::condition_variable _power_repeat_cv;
+	void handleEmergencyStopRequest(const json& j);
+	void handleOperationModeRequest(const json& j);
 	void handleCameraStreamOpenRequest(const json& j);
 	void handleCameraStreamCloseRequest(const json& j);
 	void handleJointPowerRequest(const json& j);

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -45,6 +45,7 @@ private:
 	void handleJointPowerRequest(const json& j);
 	void sendCameraStreamReport(const CameraID& cam, const std::string& b64_data);
 	void handleConnection();
+	void stopAndShutdownPowerRepeat();
 	void setRequestedJointPower(jointid_t joint, double power);
 };
 

--- a/src/world_interface/data.h
+++ b/src/world_interface/data.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../navtypes.h"
 #include "../Util.h"
+#include "../navtypes.h"
 
 #include <bitset>
 #include <chrono>
@@ -10,6 +10,7 @@
 
 #include <frozen/string.h>
 #include <frozen/unordered_map.h>
+#include <frozen/unordered_set.h>
 
 // forward declare cv::Mat instead of importing OpenCV
 // we do this to avoid unnecessarily including OpenCV in all build targets
@@ -70,6 +71,10 @@ enum class jointid_t {
 	hand,
 	drill_arm
 };
+constexpr auto all_jointid_t = frozen::make_unordered_set<jointid_t>(
+	{jointid_t::armBase, jointid_t::shoulder, jointid_t::elbow, jointid_t::forearm,
+	 jointid_t::differentialRoll, jointid_t::differentialPitch, jointid_t::hand,
+	 jointid_t::drill_arm});
 
 constexpr auto name_to_jointid = frozen::make_unordered_map<frozen::string, jointid_t>(
 	{{"armBase", jointid_t::armBase},

--- a/src/world_interface/kinematic_common_interface.cpp
+++ b/src/world_interface/kinematic_common_interface.cpp
@@ -39,10 +39,6 @@ const std::unordered_map<robot::types::jointid_t, robot::types::motorid_t> joint
 	{robot::types::jointid_t::forearm, robot::types::motorid_t::forearm},
 	{robot::types::jointid_t::hand, robot::types::motorid_t::hand}};
 
-constexpr auto jointPowerRepeatDelay = 333ms;
-std::thread jointPowerRepeatThread;
-void jointPowerRepeatTask();
-
 std::unordered_map<types::jointid_t, double> jointPowerValues{};
 std::mutex jointPowerValuesMutex;
 void setJointPowerValue(types::jointid_t joint, double power);


### PR DESCRIPTION
This PR adds a method that immediately calls `robot::setJointPower` but also stores requested joint power values in a map which are periodically read by a thread and sent to `robot::setJointPower` again, to prevent the motor boards' watchdog timers from killing the motors when the requested power does not change. The period is 1/3 of a second right now, but we can change that.

This is a draft PR for now until I can test the code (not sure if there is a watchdog timer on the simulator, so I will probably just put a debug print in setJointPower to make sure it's being called periodically), but I wanted to get the review process started.