### PR TITLE
Bugfixes for websockets

### DIFF
--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -98,8 +98,8 @@ int main(int argc, char** argv) {
 	LOG_LEVEL = LOG_INFO;
 	Globals::AUTONOMOUS = false;
 	Globals::websocketServer.start();
-	net::mc::MissionControlProtocol mcProto(Globals::websocketServer);
-	Globals::websocketServer.addProtocol(mcProto);
+	auto mcProto = std::make_unique<net::mc::MissionControlProtocol>(Globals::websocketServer);
+	Globals::websocketServer.addProtocol(std::move(mcProto));
 	robot::world_interface_init();
 	rospub::init();
 	// Ctrl+C doesn't stop the simulation without this line

--- a/src/network/websocket/WebSocketProtocol.h
+++ b/src/network/websocket/WebSocketProtocol.h
@@ -36,6 +36,8 @@ public:
 	 */
 	WebSocketProtocol(const std::string& protocolPath);
 
+	virtual ~WebSocketProtocol() = default;
+
 	/**
 	 * @brief Add a message handler for the given message type, if no handler already exists.
 	 * Messages for this message type will not be validated.

--- a/src/network/websocket/WebSocketServer.h
+++ b/src/network/websocket/WebSocketServer.h
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <optional>
 #include <thread>
 
@@ -71,7 +72,7 @@ public:
 	 * @return true iff no protocol existed with the given protocol path, and the given
 	 * protocol was successfully added.
 	 */
-	bool addProtocol(const WebSocketProtocol& protocol);
+	bool addProtocol(std::unique_ptr<WebSocketProtocol> protocol);
 
 	/**
 	 * @brief Send a string to the client connected to the given protocol path, if there is
@@ -94,8 +95,8 @@ public:
 private:
 	class ProtocolData {
 	public:
-		ProtocolData(const WebSocketProtocol& protocol);
-		WebSocketProtocol protocol;
+		ProtocolData(std::unique_ptr<WebSocketProtocol> protocol);
+		std::unique_ptr<WebSocketProtocol> protocol;
 		std::optional<connection_hdl> client;
 	};
 

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -206,18 +206,18 @@ void clientDisconnected() {
 }
 
 void initSimServer() {
-	net::websocket::WebSocketProtocol protocol(PROTOCOL_PATH);
-	protocol.addMessageHandler("simImuOrientationReport", handleIMU);
-	protocol.addMessageHandler("simLidarReport", handleLidar);
-	protocol.addMessageHandler("simGpsPositionReport", handleGPS);
-	protocol.addMessageHandler("simCameraStreamReport", handleCamFrame);
-	protocol.addMessageHandler("simMotorStatusReport", handleMotorStatus);
-	protocol.addMessageHandler("simLimitSwitchAlert", handleLimitSwitch);
-	protocol.addMessageHandler("simRoverTruePoseReport", handleTruePose);
-	protocol.addConnectionHandler(clientConnected);
-	protocol.addDisconnectionHandler(clientDisconnected);
+	auto protocol = std::make_unique<net::websocket::WebSocketProtocol>(PROTOCOL_PATH);
+	protocol->addMessageHandler("simImuOrientationReport", handleIMU);
+	protocol->addMessageHandler("simLidarReport", handleLidar);
+	protocol->addMessageHandler("simGpsPositionReport", handleGPS);
+	protocol->addMessageHandler("simCameraStreamReport", handleCamFrame);
+	protocol->addMessageHandler("simMotorStatusReport", handleMotorStatus);
+	protocol->addMessageHandler("simLimitSwitchAlert", handleLimitSwitch);
+	protocol->addMessageHandler("simRoverTruePoseReport", handleTruePose);
+	protocol->addConnectionHandler(clientConnected);
+	protocol->addDisconnectionHandler(clientDisconnected);
 
-	Globals::websocketServer.addProtocol(protocol);
+	Globals::websocketServer.addProtocol(std::move(protocol));
 
 	{
 		// wait for simulator to connect


### PR DESCRIPTION
Changed WebSocketProtocol to be OOP friendly, use unique_ptr in WebSocketServer to avoid assignment.

See [this comment](https://github.com/huskyroboticsteam/Resurgence/pull/163#issuecomment-1205682474) for an explanation of the bug that is fixed in this PR.