### PR TITLE
Added vectorD definition to navtypes, replaced usage

### DIFF
--- a/src/filters/FullPoseEstimator.cpp
+++ b/src/filters/FullPoseEstimator.cpp
@@ -9,10 +9,10 @@ namespace {
 using namespace navtypes;
 using state_t = FullPoseEstimator::state_t;
 using action_t = Eigen::Vector2d;
-using statespace::Matrixd;
+using navtypes::Matrixd;
 using statespace::NoiseCovMat;
 using statespace::NoiseCovMatX;
-using statespace::Vectord;
+using navtypes::Vectord;
 constexpr int numStates = FullPoseEstimator::numStates;
 constexpr int numSensors = FullPoseEstimator::numSensors;
 

--- a/src/filters/FullPoseEstimator.h
+++ b/src/filters/FullPoseEstimator.h
@@ -21,7 +21,7 @@ class FullPoseEstimator {
 public:
 	static constexpr int numStates = 3;
 	static constexpr int numSensors = 2;
-	using state_t = statespace::Vectord<numStates>;
+	using state_t = navtypes::Vectord<numStates>;
 
 	FullPoseEstimator(const Eigen::Vector2d& inputNoiseGains, double wheelBase, double dt,
 					  const Eigen::Vector2d& gpsStdDev, double headingStdDev);

--- a/src/filters/MultiSensorEKF.h
+++ b/src/filters/MultiSensorEKF.h
@@ -164,11 +164,11 @@ public:
 		: stateFunc(stateFunc), Q(processNoise), dt(dt), outputs(outputs) {}
 
 	void predict(const input_t& input) override {
-		statespace::Matrixd<stateDim, stateDim> F = stateFuncJacobianX(this->xHat, input);
-		statespace::Matrixd<processNoiseDim, processNoiseDim> processNoise =
+		navtypes::Matrixd<stateDim, stateDim> F = stateFuncJacobianX(this->xHat, input);
+		navtypes::Matrixd<processNoiseDim, processNoiseDim> processNoise =
 			Q.get(this->xHat, input);
 
-		statespace::Matrixd<stateDim, processNoiseDim> L =
+		navtypes::Matrixd<stateDim, processNoiseDim> L =
 			stateFuncJacobianW(this->xHat, input);
 
 		this->xHat = stateFunc(this->xHat, input, processnoise_t::Zero());
@@ -201,18 +201,18 @@ public:
 	}
 
 	void setStateFuncJacobianX(
-		const std::function<statespace::Matrixd<stateDim, stateDim>(
+		const std::function<navtypes::Matrixd<stateDim, stateDim>(
 			const state_t&, const input_t&, const processnoise_t&)>& stateFuncJacobianX) {
 		this->stateFuncJacobianXSol = stateFuncJacobianX;
 	}
 
 	void setStateFuncJacobianW(
-		const std::function<statespace::Matrixd<stateDim, processNoiseDim>(
+		const std::function<navtypes::Matrixd<stateDim, processNoiseDim>(
 			const state_t&, const input_t&, const processnoise_t&)>& stateFuncJacobianW) {
 		this->stateFuncJacobianWSol = stateFuncJacobianW;
 	}
 
-	statespace::Matrixd<stateDim, stateDim> stateFuncJacobianX(const state_t& x,
+	navtypes::Matrixd<stateDim, stateDim> stateFuncJacobianX(const state_t& x,
 															   const input_t& u) {
 		processnoise_t w = processnoise_t::Zero();
 		if (stateFuncJacobianXSol) {
@@ -223,7 +223,7 @@ public:
 		}
 	}
 
-	statespace::Matrixd<stateDim, processNoiseDim> stateFuncJacobianW(const state_t& x,
+	navtypes::Matrixd<stateDim, processNoiseDim> stateFuncJacobianW(const state_t& x,
 																	  const input_t& u) {
 		processnoise_t w = processnoise_t::Zero();
 		if (stateFuncJacobianWSol) {
@@ -240,11 +240,11 @@ private:
 	double dt;
 	std::array<Output, numOutputs> outputs;
 
-	std::function<statespace::Matrixd<stateDim, stateDim>(const state_t&, const input_t&,
+	std::function<navtypes::Matrixd<stateDim, stateDim>(const state_t&, const input_t&,
 														  const processnoise_t&)>
 		stateFuncJacobianXSol;
 
-	std::function<statespace::Matrixd<stateDim, processNoiseDim>(
+	std::function<navtypes::Matrixd<stateDim, processNoiseDim>(
 		const state_t&, const input_t&, const processnoise_t&)>
 		stateFuncJacobianWSol;
 };

--- a/src/filters/MultiSensorEKF.h
+++ b/src/filters/MultiSensorEKF.h
@@ -9,6 +9,7 @@
 #include <Eigen/Core>
 #include <Eigen/LU>
 
+using navtypes::Vectord;
 namespace filters {
 
 /**
@@ -149,9 +150,9 @@ private:
 template <int stateDim, int inputDim, int processNoiseDim, int numOutputs>
 class MultiSensorEKF : public KalmanFilterBase<stateDim, inputDim> {
 public:
-	using state_t = statespace::Vectord<stateDim>;
-	using input_t = statespace::Vectord<inputDim>;
-	using processnoise_t = statespace::Vectord<processNoiseDim>;
+	using state_t = navtypes::Vectord<stateDim>;
+	using input_t = navtypes::Vectord<inputDim>;
+	using processnoise_t = navtypes::Vectord<processNoiseDim>;
 
 	using statefunc_t =
 		std::function<state_t(const state_t&, const input_t&, const processnoise_t&)>;

--- a/src/filters/MultiSensorEKF.h
+++ b/src/filters/MultiSensorEKF.h
@@ -9,6 +9,7 @@
 #include <Eigen/Core>
 #include <Eigen/LU>
 
+using namespace navtypes;
 using navtypes::Vectord;
 namespace filters {
 

--- a/src/filters/StateSpaceUtil.h
+++ b/src/filters/StateSpaceUtil.h
@@ -10,12 +10,6 @@
  */
 namespace filters::statespace {
 
-template <int rows, int cols>
-using Matrixd = Eigen::Matrix<double, rows, cols>;
-
-template <int dim>
-using Vectord = Eigen::Matrix<double, dim, 1>;
-
 constexpr double epsilon = 1e-5;
 
 Eigen::MatrixXd

--- a/src/navtypes.h
+++ b/src/navtypes.h
@@ -29,36 +29,11 @@ using point_t =
 using points_t = std::vector<point_t>;
 using traj_points_t = std::vector<points_t>; // points_t for each time along a trajectory
 
-template <int dim>
-namespace filters::statespace {
-
 template <int rows, int cols>
 using Matrixd = Eigen::Matrix<double, rows, cols>;
 
 template <int dim>
 using Vectord = Eigen::Matrix<double, dim, 1>;
-
-constexpr double epsilon = 1e-5;
-
-Eigen::MatrixXd
-numericalJacobian(const std::function<Eigen::VectorXd(const Eigen::VectorXd&)>& func,
-				  const Eigen::VectorXd& x, int outputDim);
-
-/**
- * @brief Create a covariance matrix modelling independent variables with the given standard
- * deviations.
- *
- * @tparam size The dimension of the noise.
- * @param stdDevs The standard deviation of each element.
- * @return A size x size covariance matrix.
- */
-template <int size>
-Eigen::Matrix<double, size, size>
-createCovarianceMatrix(const Eigen::Matrix<double, size, 1>& stdDevs) {
-	Eigen::Matrix<double, size, 1> variances = stdDevs.array().square();
-	Eigen::Matrix<double, size, size> mat = variances.asDiagonal();
-	return mat;
-}
 
 struct URCLeg {
 	int left_post_id;

--- a/src/navtypes.h
+++ b/src/navtypes.h
@@ -47,6 +47,5 @@ struct URCLegGPS {
 	gpscoords_t gps;
 };
 
-x
 
 } // namespace navtypes

--- a/src/navtypes.h
+++ b/src/navtypes.h
@@ -29,6 +29,37 @@ using point_t =
 using points_t = std::vector<point_t>;
 using traj_points_t = std::vector<points_t>; // points_t for each time along a trajectory
 
+template <int dim>
+namespace filters::statespace {
+
+template <int rows, int cols>
+using Matrixd = Eigen::Matrix<double, rows, cols>;
+
+template <int dim>
+using Vectord = Eigen::Matrix<double, dim, 1>;
+
+constexpr double epsilon = 1e-5;
+
+Eigen::MatrixXd
+numericalJacobian(const std::function<Eigen::VectorXd(const Eigen::VectorXd&)>& func,
+				  const Eigen::VectorXd& x, int outputDim);
+
+/**
+ * @brief Create a covariance matrix modelling independent variables with the given standard
+ * deviations.
+ *
+ * @tparam size The dimension of the noise.
+ * @param stdDevs The standard deviation of each element.
+ * @return A size x size covariance matrix.
+ */
+template <int size>
+Eigen::Matrix<double, size, size>
+createCovarianceMatrix(const Eigen::Matrix<double, size, 1>& stdDevs) {
+	Eigen::Matrix<double, size, 1> variances = stdDevs.array().square();
+	Eigen::Matrix<double, size, size> mat = variances.asDiagonal();
+	return mat;
+}
+
 struct URCLeg {
 	int left_post_id;
 	int right_post_id; // This will be -1 for legs that are just single posts
@@ -40,5 +71,7 @@ struct URCLegGPS {
 	int right_post_id;
 	gpscoords_t gps;
 };
+
+x
 
 } // namespace navtypes

--- a/tests/filters/FullPoseEstimatorTest.cpp
+++ b/tests/filters/FullPoseEstimatorTest.cpp
@@ -8,7 +8,7 @@
 
 using namespace filters;
 using namespace navtypes;
-using filters::statespace::Vectord;
+using navtypes::Vectord;
 
 TEST_CASE("FullPoseEstimator", "[filters]") {
 	FullPoseEstimator estimator({0.01, 0.01}, Constants::EFF_WHEEL_BASE, 0.1, {0.01, 0.01},


### PR DESCRIPTION
Removed definition of `vectord` and `matrixd` from `filters::statespace` and added it to `navtypes.h`. replaced all usages of `vectord` with the appropriate location of the definition.