### PR TITLE
Require specific version of HindsightCAN

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,7 @@ find_package(nlohmann_json 3.2.0 REQUIRED)
 
 # Find the CAN library; contains packet and protocol definitions and does not
 # actually require physical CAN to be present.
-find_package(HindsightCAN REQUIRED)
+find_package(HindsightCAN 1.1.2 REQUIRED)
 
 find_package(Threads REQUIRED)
 find_package(OpenCV REQUIRED)


### PR DESCRIPTION
We occasionally make updates to the CAN library, so to ensure that we don't have bugs due to version mismatches, we will require a specific version.