### PR TITLE
Enabled javadoc autobrief

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -195,7 +195,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the JAVADOC_BANNER tag is set to YES then doxygen will interpret a line
 # such as


### PR DESCRIPTION
Minor change to the doxyfile to not require explicit `@brief` tags.