### PR TITLE
Added potentiometer support to CAN

### DIFF
--- a/src/CAN/CANMotor.h
+++ b/src/CAN/CANMotor.h
@@ -59,7 +59,7 @@ void initEncoder(deviceserial_t serial, bool invertEncoder, bool zeroEncoder,
 				 std::optional<std::chrono::milliseconds> telemetryPeriod);
 
 // TODO: figure out the correct parameters needed and implement for both motor boards
-void initPotentiometer(deviceserial_t serial, int32_t posLo, int32_t posHi,
+void initPotentiometer(deviceserial_t serial, int32_t posLo, int32_t posHi, uint16_t adcLo, uint16_t adcHi,
 					   std::optional<std::chrono::milliseconds> telemetryPeriod);
 
 /**

--- a/src/CAN/CANMotor.h
+++ b/src/CAN/CANMotor.h
@@ -58,7 +58,18 @@ void initEncoder(deviceserial_t serial, bool invertEncoder, bool zeroEncoder,
 				 int32_t pulsesPerJointRev,
 				 std::optional<std::chrono::milliseconds> telemetryPeriod);
 
-// TODO: figure out the correct parameters needed and implement for both motor boards
+/**
+ * @brief Initialize a potentiometer attached to the given motor.
+ * 
+ * @param serial The CAN serial number of the motor board.
+ * @param posLo The joint position that corresponds to @p adcLo
+ * @param posHi The joint position that corresponds to @p adcHi
+ * @param adcLo The ADC value when the joint is at @p posLo
+ * @param adcHi The ADC value when the joint is at @p posHi
+ * @param telemetryPeriod An optional parameter specifying the telemetry period.
+ * The telemetry will be fetched at this period automatically. An empty optional disables this
+ * behavior, in which case the motor position must be explicitly pulled.
+ */
 void initPotentiometer(deviceserial_t serial, int32_t posLo, int32_t posHi, uint16_t adcLo, uint16_t adcHi,
 					   std::optional<std::chrono::milliseconds> telemetryPeriod);
 

--- a/src/CAN/CANMotor_PSOC.cpp
+++ b/src/CAN/CANMotor_PSOC.cpp
@@ -11,9 +11,9 @@
 #include <vector>
 
 extern "C" {
-#include "../HindsightCAN/CANCommon.h"
-#include "../HindsightCAN/CANMotorUnit.h"
-#include "../HindsightCAN/CANPacket.h"
+#include <HindsightCAN/CANCommon.h>
+#include <HindsightCAN/CANMotorUnit.h>
+#include <HindsightCAN/CANPacket.h>
 }
 
 using namespace std::chrono_literals;
@@ -81,7 +81,8 @@ void startMonitoringMotor(deviceserial_t motor, std::chrono::milliseconds period
 } // namespace
 
 void initEncoder(deviceserial_t serial, bool invertEncoder, bool zeroEncoder,
-				 int32_t pulsesPerJointRev, std::optional<std::chrono::milliseconds> telemetryPeriod) {
+				 int32_t pulsesPerJointRev,
+				 std::optional<std::chrono::milliseconds> telemetryPeriod) {
 	auto motorGroupCode = static_cast<uint8_t>(devicegroup_t::motor);
 	CANPacket p;
 	AssembleEncoderInitializePacket(&p, motorGroupCode, serial, sensor_t::encoder,
@@ -91,6 +92,20 @@ void initEncoder(deviceserial_t serial, bool invertEncoder, bool zeroEncoder,
 	AssembleEncoderPPJRSetPacket(&p, motorGroupCode, serial, pulsesPerJointRev);
 	sendCANPacket(p);
 	std::this_thread::sleep_for(1000us);
+	if (telemetryPeriod) {
+		startMonitoringMotor(serial, telemetryPeriod.value());
+	}
+}
+
+void initPotentiometer(deviceserial_t serial, int32_t posLo, int32_t posHi, uint16_t adcLo,
+					   uint16_t adcHi,
+					   std::optional<std::chrono::milliseconds> telemetryPeriod) {
+	CANPacket packet;
+	auto group = static_cast<uint8_t>(devicegroup_t::motor);
+	AssemblePotHiSetPacket(&packet, group, serial, adcHi, posHi);
+	sendCANPacket(packet);
+	AssemblePotLoSetPacket(&packet, group, serial, adcLo, posLo);
+	sendCANPacket(packet);
 	if (telemetryPeriod) {
 		startMonitoringMotor(serial, telemetryPeriod.value());
 	}

--- a/src/CAN/FakeCANBoard.cpp
+++ b/src/CAN/FakeCANBoard.cpp
@@ -116,7 +116,11 @@ int main() {
 					int ppjr = prompt("Pulses per joint revolution");
 					can::motor::initEncoder(serial, false, true, ppjr, telemPeriod);
 				} else if (sensorType == 1) {
-					// TODO: initialize potentiometer
+					int posLo = prompt("Pos Lo");
+					int posHi = prompt("Pos Hi");
+					int adcLo = prompt("ADC Lo");
+					int adcHi = prompt("ADC Hi");
+					can::motor::initPotentiometer(serial, posLo, posHi, adcLo, adcHi, telemPeriod);
 				}
 				mode_has_been_set = true;
 			}


### PR DESCRIPTION
This adds the implementation of the pot init packet, as well as support for testing it through FakeCANBoard. This implementation has been tested on the rover hardware.