### PR TITLE
gps: Correct invalid member on collect struct

### DIFF
--- a/src/gps/gpsd_test.cpp
+++ b/src/gps/gpsd_test.cpp
@@ -49,7 +49,7 @@ static void libgps_dump_state(struct gps_data_t* collect) {
 	if (collect->set & CLIMB_SET)
 		(void)fprintf(stdout, "CLIMB: climb: %lf\n", collect->fix.climb);
 	if (collect->set & STATUS_SET)
-		(void)fprintf(stdout, "STATUS: status: %d\n", collect->status);
+		(void)fprintf(stdout, "STATUS: status: %d\n", collect->fix.status);
 	if (collect->set & MODE_SET)
 		(void)fprintf(stdout, "MODE: mode: %d\n", collect->fix.mode);
 	if (collect->set & DOP_SET)


### PR DESCRIPTION
collect struct does not have a status member. collect->fix.status does. This fixes build error when building all with 'make -j$(nproc)'. This error does not come up when building just Rover.