### PR TITLE
Add code to set limit switch limits

### DIFF
--- a/src/CAN/CANMotor.cpp
+++ b/src/CAN/CANMotor.cpp
@@ -32,6 +32,18 @@ void initMotor(deviceserial_t serial) {
 	std::this_thread::sleep_for(1000us);
 }
 
+void setLimitSwitchLimits(deviceserial_t serial, int32_t lo, int32_t hi) {
+	CANPacket p;
+	auto motorGroupCode = static_cast<uint8_t>(devicegroup_t::motor);
+
+	// 0 is low limit, 1 is high limit.
+	AssembleLimSwEncoderBoundPacket(&p, motorGroupCode, serial, 0, lo);
+	sendCANPacket(p);
+
+	AssembleLimSwEncoderBoundPacket(&p, motorGroupCode, serial, 1, hi);
+	sendCANPacket(p);
+}
+
 void setMotorPIDConstants(deviceserial_t serial, int32_t kP, int32_t kI, int32_t kD) {
 	CANPacket p;
 	auto motorGroupCode = static_cast<uint8_t>(devicegroup_t::motor);

--- a/src/CAN/CANMotor.h
+++ b/src/CAN/CANMotor.h
@@ -59,6 +59,18 @@ void initEncoder(deviceserial_t serial, bool invertEncoder, bool zeroEncoder,
 				 std::optional<std::chrono::milliseconds> telemetryPeriod);
 
 /**
+ * @brief Set the limits of the limit switch on a motor board.
+ *
+ * When the corresponding limit switch is triggered, the encoder value is set to this value.
+ * Use this method for motorboard with both encoders and limit switches
+ *
+ * @param serial The CAN serial number of the motor board.
+ * @param lo The joint position in millidegrees of the low limit switch.
+ * @param hi The joint position in millidegrees of the high limit switch.
+ */
+void setLimitSwitchLimits(deviceserial_t serial, int32_t lo, int32_t hi);
+
+/**
  * @brief Initialize a potentiometer attached to the given motor.
  *
  * @param serial The CAN serial number of the motor board.

--- a/src/CAN/FakeCANBoard.cpp
+++ b/src/CAN/FakeCANBoard.cpp
@@ -147,11 +147,11 @@ int main() {
 					can::addDeviceTelemetryCallback(
 						id, can::telemtype_t::limit_switch,
 						[](can::deviceid_t id, can::telemtype_t telemType,
-						DataPoint<can::telemetry_t> data) {
+						   DataPoint<can::telemetry_t> data) {
 							std::cout << "Motor Limit: serial=" << std::hex
-									<< static_cast<int>(id.second)
-									<< ", data=" << std::bitset<8>(data.getDataOrElse(0))
-									<< std::endl;
+									  << static_cast<int>(id.second)
+									  << ", data=" << std::bitset<8>(data.getDataOrElse(0))
+									  << std::endl;
 						});
 				}
 				mode_has_been_set = true;

--- a/src/world_interface/real_world_constants.h
+++ b/src/world_interface/real_world_constants.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
-#include <utility>
 
 #include <frozen/unordered_map.h>
 #include <frozen/unordered_set.h>
@@ -60,17 +59,20 @@ struct encparams_t {
 };
 
 // TODO: verify limit switch limits
-constexpr auto encMotors =
-	frozen::make_unordered_map<motorid_t, encparams_t>({{motorid_t::shoulder,
-														 {.isInverted = false,
-														  .ppjr = 1620 * 1024,
-														  .limitSwitchLow = -90000,
-														  .limitSwitchHigh = 90000}},
-														{motorid_t::elbow,
-														 {.isInverted = true,
-														  .ppjr = 1620 * 1024,
-														  .limitSwitchLow = -90000,
-														  .limitSwitchHigh = 90000}}});
+// clang-format off
+constexpr auto encMotors = frozen::make_unordered_map<motorid_t, encparams_t>({
+	{motorid_t::shoulder,
+		{.isInverted = false,
+		.ppjr = 1620 * 1024,
+		.limitSwitchLow = -90000,
+		.limitSwitchHigh = 90000}},
+	{motorid_t::elbow,
+		{.isInverted = true,
+		.ppjr = 1620 * 1024,
+		.limitSwitchLow = -90000,
+		.limitSwitchHigh = 90000}}
+});
+// clang-format on
 
 constexpr auto potMotors = frozen::make_unordered_map<motorid_t, potparams_t>(
 	{{motorid_t::armBase,

--- a/src/world_interface/real_world_constants.h
+++ b/src/world_interface/real_world_constants.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include <frozen/unordered_map.h>
 #include <frozen/unordered_set.h>
@@ -81,6 +82,12 @@ constexpr auto motorSerialIDMap = frozen::make_unordered_map<motorid_t, can::dev
 	 {motorid_t::wrist, DEVICE_SERIAL_MOTOR_WRIST},
 	 {motorid_t::hand, DEVICE_SERIAL_MOTOR_HAND},
 	 {motorid_t::activeSuspension, DEVICE_SERIAL_LINEAR_ACTUATOR}});
+
+// TODO: verify limit switch limits
+/** @brief Maps motors to their corresponding limit switch limits, if they have them. */
+constexpr auto limitSwitchLimitsMap =
+	frozen::make_unordered_map<motorid_t, std::pair<int32_t, int32_t>>(
+		{{motorid_t::shoulder, {-90000, 90000}}, {motorid_t::elbow, {-90000, 90000}}});
 
 // TODO: tune pid
 /** @brief A mapping of PID controlled motors to their pid coefficients. */

--- a/src/world_interface/real_world_constants.h
+++ b/src/world_interface/real_world_constants.h
@@ -53,11 +53,24 @@ struct encparams_t {
 	bool isInverted;
 	/** Encoder pulses count per joint revolution */
 	int ppjr;
+	/** Limit switch low, in millidegrees */
+	int limitSwitchLow;
+	/** Limit switch high, in millidegrees */
+	int limitSwitchHigh;
 };
 
-constexpr auto encMotors = frozen::make_unordered_map<motorid_t, encparams_t>(
-	{{motorid_t::shoulder, {.isInverted = false, .ppjr = 1620 * 1024}},
-	 {motorid_t::elbow, {.isInverted = true, .ppjr = 1620 * 1024}}});
+// TODO: verify limit switch limits
+constexpr auto encMotors =
+	frozen::make_unordered_map<motorid_t, encparams_t>({{motorid_t::shoulder,
+														 {.isInverted = false,
+														  .ppjr = 1620 * 1024,
+														  .limitSwitchLow = -90000,
+														  .limitSwitchHigh = 90000}},
+														{motorid_t::elbow,
+														 {.isInverted = true,
+														  .ppjr = 1620 * 1024,
+														  .limitSwitchLow = -90000,
+														  .limitSwitchHigh = 90000}}});
 
 constexpr auto potMotors = frozen::make_unordered_map<motorid_t, potparams_t>(
 	{{motorid_t::armBase,
@@ -82,12 +95,6 @@ constexpr auto motorSerialIDMap = frozen::make_unordered_map<motorid_t, can::dev
 	 {motorid_t::wrist, DEVICE_SERIAL_MOTOR_WRIST},
 	 {motorid_t::hand, DEVICE_SERIAL_MOTOR_HAND},
 	 {motorid_t::activeSuspension, DEVICE_SERIAL_LINEAR_ACTUATOR}});
-
-// TODO: verify limit switch limits
-/** @brief Maps motors to their corresponding limit switch limits, if they have them. */
-constexpr auto limitSwitchLimitsMap =
-	frozen::make_unordered_map<motorid_t, std::pair<int32_t, int32_t>>(
-		{{motorid_t::shoulder, {-90000, 90000}}, {motorid_t::elbow, {-90000, 90000}}});
 
 // TODO: tune pid
 /** @brief A mapping of PID controlled motors to their pid coefficients. */

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -62,10 +62,9 @@ void ensureMotorMode(motorid_t motor, motormode_t mode) {
 }
 
 void initMotors() {
-	can::motor::initMotor(motorSerialIDMap.at(motorid_t::frontLeftWheel));
-	can::motor::initMotor(motorSerialIDMap.at(motorid_t::frontRightWheel));
-	can::motor::initMotor(motorSerialIDMap.at(motorid_t::rearLeftWheel));
-	can::motor::initMotor(motorSerialIDMap.at(motorid_t::rearRightWheel));
+	for (const auto& it : motorSerialIDMap) {
+		can::motor::initMotor(it.second);
+	}
 
 	for (const auto& pot_motor_pair : robot::potMotors) {
 		motorid_t motor_id = pot_motor_pair.first;
@@ -97,7 +96,10 @@ void initMotors() {
 		can::motor::setMotorPIDConstants(serial, pid.kP, pid.kI, pid.kD);
 	}
 
-	can::motor::initMotor(motorSerialIDMap.at(motorid_t::hand));
+	for (const auto& it : limitSwitchLimitsMap) {
+		auto limits = it.second;
+		can::motor::setLimitSwitchLimits(motorSerialIDMap.at(it.first), limits.first, limits.second);
+	}
 }
 
 void setupCameras() {

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -98,7 +98,8 @@ void initMotors() {
 
 	for (const auto& it : limitSwitchLimitsMap) {
 		auto limits = it.second;
-		can::motor::setLimitSwitchLimits(motorSerialIDMap.at(it.first), limits.first, limits.second);
+		can::motor::setLimitSwitchLimits(motorSerialIDMap.at(it.first), limits.first,
+										 limits.second);
 	}
 }
 

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -72,7 +72,6 @@ void initMotors() {
 
 		can::deviceserial_t serial = motorSerialIDMap.at(motor_id);
 
-		can::motor::initMotor(serial);
 		can::motor::initPotentiometer(serial, pot_params.mdeg_lo, pot_params.mdeg_hi,
 									  pot_params.adc_lo, pot_params.adc_hi, TELEM_PERIOD);
 	}
@@ -83,23 +82,16 @@ void initMotors() {
 
 		can::deviceserial_t serial = motorSerialIDMap.at(motor_id);
 
-		can::motor::initMotor(serial);
 		can::motor::initEncoder(serial, enc_params.isInverted, true, enc_params.ppjr,
 								TELEM_PERIOD);
-
-		// TODO: set limit switch limits
+		can::motor::setLimitSwitchLimits(serial, enc_params.limitSwitchLow,
+										 enc_params.limitSwitchHigh);
 	}
 
 	for (motorid_t motor : pidMotors) {
 		can::deviceserial_t serial = motorSerialIDMap.at(motor);
 		pidcoef_t pid = motorPIDMap.at(motor);
 		can::motor::setMotorPIDConstants(serial, pid.kP, pid.kI, pid.kD);
-	}
-
-	for (const auto& it : limitSwitchLimitsMap) {
-		auto limits = it.second;
-		can::motor::setLimitSwitchLimits(motorSerialIDMap.at(it.first), limits.first,
-										 limits.second);
 	}
 }
 


### PR DESCRIPTION
This adds code in the CAN layer to allow configuring the limit switch limits, so that the motor boards can reset encoder positions when they are triggered.