### PR TITLE
Set dep versions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt install -y build-essential wget unzip curl gnupg2 lsb-release git \
           cmake libsfml-dev libeigen3-dev libopencv-dev libopencv-contrib-dev \
           libwebsocketpp-dev libboost-system-dev gpsd gpsd-clients libgps-dev nlohmann-json3-dev \
-          catch2 urg-lidar rplidar ublox-linux hindsight-can h264encoder frozen libargparse-dev
+          catch2 urg-lidar rplidar ublox-linux hindsight-can=1.3.0 h264encoder=1.1.1 frozen libargparse-dev
     - name: Build codebase
       run: |
         cd ${{ github.workspace }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Resurgence
 Main onboard codebase for the Husky Robotics rover.
 
+# Updating Dependencies
+
+Some of our dependencies are team-managed, including the CAN library and the H264Encoder. Leads can use the [ubuntu-repo](https://github.com/huskyroboticsteam/ubuntu-repo) to create new builds of these dependencies when they are updated.
+
+**IMPORTANT:** When a dependency is updated, remember to update the required version number in [CMakeLists.txt](src/CMakeLists.txt) as well as in the [CI script](.github/workflows/ccpp.yml).
+
 # Pre-Setup Notes
 
 Our codebase is developed for an NVIDIA Jetson TX2, which runs Ubuntu Linux; as such, much


### PR DESCRIPTION
Our build breaks whenever one of our team dependencies has a newer version available that we don't want to migrate to yet. Explicitly specifying the version will fix this.