### PR TITLE
negate hand pwm scales

### DIFF
--- a/src/world_interface/real_world_constants.h
+++ b/src/world_interface/real_world_constants.h
@@ -122,7 +122,7 @@ constexpr auto positive_pwm_scales =
 												   {motorid_t::frontRightWheel, -0.7},
 												   {motorid_t::rearLeftWheel, 0.7},
 												   {motorid_t::rearRightWheel, 0.7},
-												   {motorid_t::hand, 0.75},
+												   {motorid_t::hand, -0.75},
 												   {motorid_t::activeSuspension, 1.0}});
 /**
  * @brief A mapping of motorids to power scale factors when commanded with negative power.
@@ -138,7 +138,7 @@ constexpr auto negative_pwm_scales =
 												   {motorid_t::frontRightWheel, -0.7},
 												   {motorid_t::rearLeftWheel, 0.7},
 												   {motorid_t::rearRightWheel, 0.7},
-												   {motorid_t::hand, 0.75},
+												   {motorid_t::hand, -0.75},
 												   {motorid_t::activeSuspension, 1.0}});
 
 } // namespace robot


### PR DESCRIPTION
Agreed on Saturday that left trigger should open the hand and right trigger should close.