### PR TITLE
Don't send zero power in power repeat task

### DIFF
--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -388,7 +388,11 @@ void MissionControlProtocol::jointPowerRepeatTask() {
 				}
 				const jointid_t& joint = current_pair.first;
 				const double& power = current_pair.second;
-				robot::setJointPower(joint, power);
+				// no need to repeatedly send 0 power
+				// this is also needed to make the zero calibration script work
+				if (power != 0.0) {
+					robot::setJointPower(joint, power);
+				}
 			}
 			if (this->_last_cmd_vel) {
 				robot::setCmdVel(this->_last_cmd_vel->first, this->_last_cmd_vel->second);


### PR DESCRIPTION
1) This reduced CAN bus usage
2) This is required for the limit switch calibration script, since it'll be sending power commands to the rover while the rover executable is running. Repeatedly sending zero power would cause conflicts.