### PR TITLE
Commented out sendRoverPos in MCP

### DIFF
--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -393,7 +393,8 @@ void MissionControlProtocol::telemReportTask() {
 			}
 		}
 
-		sendRoverPos();
+		// TODO: this crashes the thread, debug sendRoverPos()!
+		// sendRoverPos();
 
 		pt += TELEM_REPORT_PERIOD;
 		std::this_thread::sleep_until(pt);


### PR DESCRIPTION
sendRoverPos appears to crash the telemReportTask thread.