### PR TITLE
E-Stop when exiting

### DIFF
--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -30,6 +30,7 @@ using namespace navtypes;
 using namespace robot::types;
 
 void closeRover(int signum) {
+	robot::emergencyStop();
 	rospub::shutdown();
 	Globals::websocketServer.stop();
 	raise(SIGTERM);


### PR DESCRIPTION
When the rover exits it should emergency stop all motors. Technically PWM will be killed by the motor watchdogs, but PID control won't be. So if the rover exits while PID is running, it'll keep executing that pid command. Which is bad.