### PR TITLE
Add general telemetry prompting to FakeCANBoard

### DIFF
--- a/src/CAN/CAN.cpp
+++ b/src/CAN/CAN.cpp
@@ -70,7 +70,8 @@ const std::unordered_map<telemetrycode_t, telemtype_t> telemCodeToTypeMap = {
 	{PACKET_TELEMETRY_GYRO_X, telemtype_t::gyro_x},
 	{PACKET_TELEMETRY_GYRO_Y, telemtype_t::gyro_y},
 	{PACKET_TELEMETRY_GYRO_Z, telemtype_t::gyro_z},
-	{PACKET_TELEMETRY_LIM_SW_STATE, telemtype_t::limit_switch}};
+	{PACKET_TELEMETRY_LIM_SW_STATE, telemtype_t::limit_switch},
+	{PACKET_TELEMETRY_ADC_RAW, telemtype_t::adc_raw}};
 
 // the telemetry map will store telemetry code instead of telem enum
 // this means unrecognized telemetry types won't cause UB

--- a/src/CAN/CANUtils.h
+++ b/src/CAN/CANUtils.h
@@ -48,8 +48,9 @@ enum class telemtype_t {
 	gyro_x = PACKET_TELEMETRY_GYRO_X,
 	gyro_y = PACKET_TELEMETRY_GYRO_Y,
 	gyro_z = PACKET_TELEMETRY_GYRO_Z,
-	limit_switch = PACKET_TELEMETRY_LIM_SW_STATE
-	// TODO: add further telemetry types if required
+	limit_switch = PACKET_TELEMETRY_LIM_SW_STATE,
+	adc_raw = PACKET_TELEMETRY_ADC_RAW
+	// add further telemetry types if required
 };
 
 /**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,7 +109,7 @@ find_package(nlohmann_json 3.2.0 REQUIRED)
 
 # Find the CAN library; contains packet and protocol definitions and does not
 # actually require physical CAN to be present.
-find_package(HindsightCAN 1.3.2 REQUIRED)
+find_package(HindsightCAN 1.4.0 REQUIRED)
 
 find_package(Threads REQUIRED)
 find_package(OpenCV REQUIRED)

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -4,5 +4,5 @@ sudo apt update
 sudo apt install -y build-essential unzip gnupg2 lsb-release git \
 	cmake libeigen3-dev libopencv-dev libopencv-contrib-dev \
 	libwebsocketpp-dev libboost-system-dev gpsd gpsd-clients libgps-dev nlohmann-json3-dev \
-	catch2 urg-lidar rplidar ublox-linux hindsight-can=1.3.2 frozen libargparse-dev libavutil-dev \
+	catch2 urg-lidar rplidar ublox-linux hindsight-can=1.4.0 frozen libargparse-dev libavutil-dev \
 	libx264-dev


### PR DESCRIPTION
This lets us prompt for arbitrary telemetry types, which will be useful for pot testing, and other stuff too.