### PR TITLE
Tune active suspension, fix validator

### DIFF
--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -162,9 +162,9 @@ void MissionControlProtocol::setRequestedCmdVel(double dtheta, double dx) {
 
 static bool validateJoint(const json& j) {
 	return util::validateKey(j, "joint", val_t::string) &&
-		   util::validateOneOf(j, "joint",
-							   {"armBase", "shoulder", "elbow", "forearm", "wrist", "hand",
-								"ikUp", "ikForward"});
+		   std::any_of(all_jointid_t.begin(), all_jointid_t.end(), [&](const auto& joint) {
+			   return j["joint"].get<std::string>() == util::to_string(joint);
+		   });
 }
 
 static bool validateJointPowerRequest(const json& j) {

--- a/src/world_interface/real_world_constants.h
+++ b/src/world_interface/real_world_constants.h
@@ -121,7 +121,7 @@ constexpr auto positive_pwm_scales =
 												   {motorid_t::rearLeftWheel, 0.7},
 												   {motorid_t::rearRightWheel, 0.7},
 												   {motorid_t::hand, -0.75},
-												   {motorid_t::activeSuspension, 1.0}});
+												   {motorid_t::activeSuspension, -0.5}});
 /**
  * @brief A mapping of motorids to power scale factors when commanded with negative power.
  * Negative values mean that the motor is inverted.
@@ -137,6 +137,6 @@ constexpr auto negative_pwm_scales =
 												   {motorid_t::rearLeftWheel, 0.7},
 												   {motorid_t::rearRightWheel, 0.7},
 												   {motorid_t::hand, -0.75},
-												   {motorid_t::activeSuspension, 1.0}});
+												   {motorid_t::activeSuspension, -0.5}});
 
 } // namespace robot


### PR DESCRIPTION
Tunes the active suspension pwm scales, and also fixes the joint validator to not use a hardcoded list of joint names.