### PR TITLE
Install hindsightcan with fetchcontent

### DIFF
--- a/src/CAN/CAN.cpp
+++ b/src/CAN/CAN.cpp
@@ -23,7 +23,7 @@
 #include <sys/types.h>
 
 extern "C" {
-#include "../HindsightCAN/CANCommon.h"
+#include <HindsightCAN/CANCommon.h>
 }
 
 using robot::types::DataPoint;

--- a/src/CAN/CANMotor.cpp
+++ b/src/CAN/CANMotor.cpp
@@ -8,9 +8,9 @@
 #include <thread>
 
 extern "C" {
-#include "../HindsightCAN/CANCommon.h"
-#include "../HindsightCAN/CANMotorUnit.h"
-#include "../HindsightCAN/CANPacket.h"
+#include <HindsightCAN/CANCommon.h>
+#include <HindsightCAN/CANMotorUnit.h>
+#include <HindsightCAN/CANPacket.h>
 }
 
 using namespace std::chrono_literals;

--- a/src/CAN/CANMotor_AVR.cpp
+++ b/src/CAN/CANMotor_AVR.cpp
@@ -6,9 +6,9 @@
 #include <thread>
 
 extern "C" {
-#include "../HindsightCAN/CANCommon.h"
-#include "../HindsightCAN/CANMotorUnit.h"
-#include "../HindsightCAN/CANPacket.h"
+#include <HindsightCAN/CANCommon.h>
+#include <HindsightCAN/CANMotorUnit.h>
+#include <HindsightCAN/CANPacket.h>
 }
 
 using namespace std::chrono_literals;

--- a/src/CAN/CANUtils.cpp
+++ b/src/CAN/CANUtils.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 
 extern "C" {
-#include "../HindsightCAN/CANPacket.h"
+#include <HindsightCAN/CANPacket.h>
 }
 
 namespace can {

--- a/src/CAN/FakeCANBoard.cpp
+++ b/src/CAN/FakeCANBoard.cpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 extern "C" {
-#include "../HindsightCAN/CANScience.h"
+#include <HindsightCAN/CANScience.h>
 }
 
 using namespace std::chrono_literals;

--- a/src/CAN/TestIMU.cpp
+++ b/src/CAN/TestIMU.cpp
@@ -1,8 +1,8 @@
 #include "../log.h"
 #include "CAN.h"
 extern "C" {
-#include "../HindsightCAN/CANCommon.h"
-#include "../HindsightCAN/CANSerialNumbers.h"
+#include <HindsightCAN/CANCommon.h>
+#include <HindsightCAN/CANSerialNumbers.h>
 }
 
 #include <chrono>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(Rover LANGUAGES CXX C)
 
+include(FetchContent)
+
 # If a build type was not explicitly specified, default to "RelWithDebInfo" (Same optimization
 # as the "Release" configuration but with debugging symbols).
 #
@@ -109,7 +111,12 @@ find_package(nlohmann_json 3.2.0 REQUIRED)
 
 # Find the CAN library; contains packet and protocol definitions and does not
 # actually require physical CAN to be present.
-find_package(HindsightCAN 1.4.0 REQUIRED)
+FetchContent_Declare(
+    HindsightCAN
+    GIT_REPOSITORY https://github.com/huskyroboticsteam/HindsightCAN.git
+    GIT_TAG 09d0b2785ccd27536ca0381146b822205f2fad47 # TODO: update after pr is merged
+)
+FetchContent_MakeAvailable(HindsightCAN)
 
 find_package(Threads REQUIRED)
 find_package(OpenCV REQUIRED)
@@ -197,7 +204,7 @@ else()
     CAN/CANStubs.cpp)
 endif()
 target_link_libraries(can_interface PUBLIC
-  HindsightCAN::HindsightCAN
+  HindsightCAN
   Threads::Threads
   utils
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,7 +114,7 @@ find_package(nlohmann_json 3.2.0 REQUIRED)
 FetchContent_Declare(
     HindsightCAN
     GIT_REPOSITORY https://github.com/huskyroboticsteam/HindsightCAN.git
-    GIT_TAG 09d0b2785ccd27536ca0381146b822205f2fad47 # TODO: update after pr is merged
+    GIT_TAG 7397787fbb04687bf03c8fbac9a1db56f245fc9a
 )
 FetchContent_MakeAvailable(HindsightCAN)
 

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -4,5 +4,5 @@ sudo apt update
 sudo apt install -y build-essential unzip gnupg2 lsb-release git \
 	cmake libeigen3-dev libopencv-dev libopencv-contrib-dev \
 	libwebsocketpp-dev libboost-system-dev gpsd gpsd-clients libgps-dev nlohmann-json3-dev \
-	catch2 urg-lidar rplidar ublox-linux hindsight-can=1.4.0 frozen libargparse-dev libavutil-dev \
+	catch2 urg-lidar rplidar ublox-linux frozen libargparse-dev libavutil-dev \
 	libx264-dev


### PR DESCRIPTION
This PR makes it so that HindsightCAN no longer needs to be installed with `apt-get`, and uses `FetchContent` to fetch it at configure-time instead. This makes it easier to develop in the future, and removes the hassle of managing that dependency in the ubuntu repo.

This should be merged after the corresponding PR in HindsightCAN: https://github.com/huskyroboticsteam/HindsightCAN/pull/47

Note: remember to update the commit hash in CMakeLists.txt after merging the above pr.