### PR TITLE
Report full attitude, fix lat/lon bug, report attitude even if no gps fix

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,3 +17,4 @@ IncludeCategories:
     Priority:	3
 IndentCaseLabels: true
 PointerAlignment: Left
+AlwaysBreakTemplateDeclarations: Yes

--- a/src/ardupilot/ArduPilotInterface.cpp
+++ b/src/ardupilot/ArduPilotInterface.cpp
@@ -25,11 +25,7 @@ DataPoint<gpscoords_t> readGPSCoords() {
 } // namespace gps
 
 namespace robot {
-DataPoint<double> readIMUHeading() {
-	auto imu_heading = ardupilot_protocol->getIMU();
-	if (imu_heading.isValid()) {
-		return DataPoint<double>(imu_heading.getTime(), imu_heading.getData().yaw);
-	}
-	return DataPoint<double>();
+types::DataPoint<eulerangles_t> readIMU() {
+	return ardupilot_protocol->getIMU();
 }
 } // namespace robot

--- a/src/ardupilot/ArduPilotInterface.cpp
+++ b/src/ardupilot/ArduPilotInterface.cpp
@@ -25,7 +25,7 @@ DataPoint<gpscoords_t> readGPSCoords() {
 } // namespace gps
 
 namespace robot {
-types::DataPoint<eulerangles_t> readIMU() {
+DataPoint<eulerangles_t> readIMU() {
 	return ardupilot_protocol->getIMU();
 }
 } // namespace robot

--- a/src/ardupilot/ArduPilotProtocol.cpp
+++ b/src/ardupilot/ArduPilotProtocol.cpp
@@ -65,7 +65,7 @@ bool ArduPilotProtocol::validateGPSRequest(const json& j) {
 
 void ArduPilotProtocol::handleGPSRequest(const json& j) {
 	double lat = j["lat"];
-	double lon = j["lat"];
+	double lon = j["lon"];
 	{
 		std::lock_guard<std::mutex> lock(_lastGPSMutex);
 		_lastGPS = gpscoords_t{lat, lon};

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -4,6 +4,7 @@
 #include "../Globals.h"
 #include "../base64/base64_img.h"
 #include "../log.h"
+#include "../utils/core.h"
 #include "../utils/json.h"
 #include "../world_interface/data.h"
 #include "../world_interface/world_interface.h"
@@ -187,7 +188,8 @@ void MissionControlProtocol::handleJointPowerRequest(const json& j) {
 void MissionControlProtocol::sendRoverPos() {
 	auto imu = robot::readIMU();
 	auto gps = gps::readGPSCoords();
-	log(LOG_DEBUG, "imu=%d, gps=%d\n", imu.isValid(), gps.isValid());
+	log(LOG_DEBUG, "imu_valid=%d, gps_valid=%d\n", util::to_string(imu.isValid()),
+		util::to_string(gps.isValid()));
 	if (imu.isValid()) {
 		auto rpy = imu.getData();
 		Eigen::Quaterniond quat(Eigen::AngleAxisd(rpy.roll, Eigen::Vector3d::UnitX()) *

--- a/src/utils/core.cpp
+++ b/src/utils/core.cpp
@@ -6,6 +6,11 @@ bool almostEqual(double a, double b, double threshold) {
 	return std::abs(a - b) < threshold;
 }
 
+template <>
+std::string to_string<bool>(const bool& val) {
+	return val ? "true" : "false";
+}
+
 frozen::string freezeStr(const std::string& str) {
 	return frozen::string(str.c_str(), str.size());
 }

--- a/src/utils/core.h
+++ b/src/utils/core.h
@@ -44,9 +44,19 @@ std::unordered_set<K> keySet(const std::unordered_map<K, V>& input) {
  * @return A string representation of that value, as a std::string. The exact representation of
  * the value is up to the implementation.
  */
-template <typename T> std::string to_string(const T& val) {
+template <typename T>
+std::string to_string(const T& val) {
 	return std::to_string(val);
 }
+
+/**
+ * @brief Converts a boolean to a string.
+ *
+ * @param val The value to get the string representation of.
+ * @return "true" iff val, otherwise "false".
+ */
+template <>
+std::string to_string<bool>(const bool& val);
 
 /**
  * @brief Convert the given std::string to a frozen::string.

--- a/src/world_interface/gps_common_interface.cpp
+++ b/src/world_interface/gps_common_interface.cpp
@@ -10,6 +10,10 @@ static std::optional<GPSToMetersConverter> converter;
 
 namespace robot {
 
+DataPoint<double> readIMUHeading() {
+	return readIMU().transform([](const navtypes::eulerangles_t& e) { return e.yaw; });
+}
+
 DataPoint<point_t> readGPS() {
 	DataPoint<gpscoords_t> coords = gps::readGPSCoords();
 	if (!coords) {

--- a/src/world_interface/noop_world.cpp
+++ b/src/world_interface/noop_world.cpp
@@ -43,7 +43,7 @@ landmarks_t readLandmarks() {
 	return landmarks_t{};
 }
 
-DataPoint<double> readIMUHeading() {
+types::DataPoint<navtypes::eulerangles_t> readIMU() {
 	return {};
 }
 

--- a/src/world_interface/noop_world.cpp
+++ b/src/world_interface/noop_world.cpp
@@ -43,7 +43,7 @@ landmarks_t readLandmarks() {
 	return landmarks_t{};
 }
 
-types::DataPoint<navtypes::eulerangles_t> readIMU() {
+DataPoint<navtypes::eulerangles_t> readIMU() {
 	return {};
 }
 

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -368,7 +368,7 @@ DataPoint<pose_t> readVisualOdomVel() {
 	return DataPoint<pose_t>{};
 }
 
-types::DataPoint<navtypes::eulerangles_t> readIMU() {
+DataPoint<navtypes::eulerangles_t> readIMU() {
 	std::lock_guard<std::mutex> guard(attitudeMutex);
 	return lastAttitude;
 }

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -41,8 +41,8 @@ const std::map<motorid_t, std::string> motorNameMap = {
 	{motorid_t::wrist, "wrist"},
 	{motorid_t::hand, "hand"}};
 
-DataPoint<double> lastHeading;
-std::mutex headingMutex;
+DataPoint<navtypes::eulerangles_t> lastAttitude;
+std::mutex attitudeMutex;
 
 DataPoint<gpscoords_t> lastGPS;
 std::mutex gpsMutex;
@@ -149,8 +149,12 @@ void handleIMU(json msg) {
 	double qw = msg["w"];
 
 	double heading = util::quatToHeading(qw, qx, qy, qz);
-	std::lock_guard<std::mutex> guard(headingMutex);
-	lastHeading = {heading};
+	Eigen::Quaterniond q(qw, qx, qy, qz);
+	q.normalize();
+	Eigen::Vector3d euler = q.toRotationMatrix().eulerAngles(0, 1, 2);
+	std::lock_guard<std::mutex> guard(attitudeMutex);
+	lastAttitude =
+		navtypes::eulerangles_t{.roll = euler(0), .pitch = euler(1), .yaw = euler(2)};
 }
 
 void handleCamFrame(json msg) {
@@ -364,9 +368,9 @@ DataPoint<pose_t> readVisualOdomVel() {
 	return DataPoint<pose_t>{};
 }
 
-DataPoint<double> readIMUHeading() {
-	std::lock_guard<std::mutex> guard(headingMutex);
-	return lastHeading;
+types::DataPoint<navtypes::eulerangles_t> readIMU() {
+	std::lock_guard<std::mutex> guard(attitudeMutex);
+	return lastAttitude;
 }
 
 DataPoint<pose_t> getTruePose() {

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -166,6 +166,17 @@ types::DataPoint<navtypes::point_t> readGPS();
 types::DataPoint<double> readIMUHeading();
 
 /**
+ * @brief Read the rover attitude from the IMU.
+ *
+ * Euler angles are in radians, in RPY format (i.e. XYZ extrinsic)
+ *
+ * @see https://en.wikipedia.org/wiki/Euler_angles#Tait%E2%80%93Bryan_angles
+ *
+ * @return types::DataPoint<navtypes::eulerangles_t>
+ */
+types::DataPoint<navtypes::eulerangles_t> readIMU();
+
+/**
  * @brief Get the ground truth pose, if available. This is only available in simulation.
  *
  * @return DataPoint<pose_t> The ground truth pose, or an empty datapoint if unavailable.


### PR DESCRIPTION
This PR adds `readIMU()` to the world interface, which allows reading the full attitude. It also includes some refactoring, since `readIMUHeading()` is now obviously a subset of `readIMU()`.

Also includes a bugfix where `lat` was repeated twice instead of `lat` and `lon`.