### PR TITLE
Arm Inverse Kinematics Updates

### DIFF
--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -147,7 +147,7 @@ void MissionControlProtocol::handleRequestArmIKEnabled(const json& j) {
 					std::thread(&MissionControlProtocol::updateArmIKRepeatTask, this);
 			} else {
 				// unable to enable IK
-				log(LOG_WARN, "Unable to enable IK");
+				LOG_F(WARNING, "Unable to enable IK");
 			}
 		}
 	} else {

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -139,14 +139,7 @@ void MissionControlProtocol::handleRequestArmIKEnabled(const json& j) {
 		}
 		DataPoint<navtypes::Vectord<Constants::arm::IK_MOTORS.size()>> armJointPositions =
 			robot::getMotorPositionsRad(Constants::arm::IK_MOTORS);
-		// TODO: there should be a better way of handling invalid data than crashing.
-		// It should somehow just not enable IK, but then it needs to communicate back to MC
-		// that IK wasn't enabled?
-		// FIX: Change setArmIKOn to requestArmIKEnable.
-		// Create new packet: armIKEnabledReport packet
 		// Rover responds with armIKEnabledReport after requestArmIKEnable is processed
-		// On Mission Control side, if armIKEnabledReport is false after trying to enable,
-		// give an alert stating that IK was unable to activated.
 		if (armJointPositions.isValid()) {
 			Globals::planarArmController.set_setpoint(armJointPositions.getData());
 			Globals::armIKEnabled = true;

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -292,6 +292,7 @@ void MissionControlProtocol::handleConnection() {
 	}
 
 	this->_server.sendJSON(Constants::MC_PROTOCOL_NAME, j);
+	sendArmIKEnabledReport();
 
 	if (!Globals::AUTONOMOUS) {
 		// start power repeat thread (if not already running)

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -264,8 +264,7 @@ void MissionControlProtocol::handleCameraStreamCloseRequest(const json& j) {
 }
 
 void MissionControlProtocol::sendArmIKEnabledReport() {
-	json msg = {{"type", ARM_IK_ENABLED_REP_TYPE},
-				{"enabled", Globals::armIKEnabled}};
+	json msg = {{"type", ARM_IK_ENABLED_REP_TYPE}, {"enabled", Globals::armIKEnabled}};
 	this->_server.sendJSON(Constants::MC_PROTOCOL_NAME, msg);
 }
 

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -159,7 +159,7 @@ void MissionControlProtocol::handleRequestArmIKEnabled(const json& j) {
 			_arm_ik_repeat_thread.join();
 		}
 	}
-	sendArmIKEnabledReport(Globals::armIKEnabled);
+	sendArmIKEnabledReport();
 }
 
 void MissionControlProtocol::setRequestedCmdVel(double dtheta, double dx) {
@@ -264,7 +264,7 @@ void MissionControlProtocol::handleCameraStreamCloseRequest(const json& j) {
 }
 
 void MissionControlProtocol::sendArmIKEnabledReport() {
-	json msg = {{"type", ARM_IK_ENABLED_REP_TYPE}, {"enabled", Globals::armIKEnabled}};
+	json msg = {{"type", ARM_IK_ENABLED_REP_TYPE}, {"enabled", Globals::armIKEnabled.load()}};
 	this->_server.sendJSON(Constants::MC_PROTOCOL_NAME, msg);
 }
 

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -87,6 +87,9 @@ void MissionControlProtocol::handleEmergencyStopRequest(const json& j) {
 	// TODO: reinit motors
 	Globals::E_STOP = stop;
 	Globals::armIKEnabled = false;
+
+	// inform MC that Ik has been disabled
+	sendArmIKEnabledReport();
 }
 
 static bool validateOperationModeRequest(const json& j) {

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -419,7 +419,7 @@ MissionControlProtocol::~MissionControlProtocol() {
 	}
 }
 
-void MissionControlProtocol::setArmIKEnabled(const bool enabled) {
+void MissionControlProtocol::setArmIKEnabled(bool enabled) {
 	Globals::armIKEnabled = enabled;
 	this->sendArmIKEnabledReport();
 }

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -86,7 +86,7 @@ void MissionControlProtocol::handleEmergencyStopRequest(const json& j) {
 	}
 	// TODO: reinit motors
 	Globals::E_STOP = stop;
-	this->setArmIKEnabled();
+	this->setArmIKEnabled(false);
 }
 
 static bool validateOperationModeRequest(const json& j) {

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -145,6 +145,9 @@ void MissionControlProtocol::handleRequestArmIKEnabled(const json& j) {
 			Globals::armIKEnabled = true;
 			_arm_ik_repeat_thread =
 				std::thread(&MissionControlProtocol::updateArmIKRepeatTask, this);
+		} else {
+			// unable to enable IK
+			log(LOG_WARN, "Unable to enable IK");
 		}
 	} else {
 		Globals::armIKEnabled = false;

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -148,6 +148,7 @@ void MissionControlProtocol::handleRequestArmIKEnabled(const json& j) {
 			} else {
 				// unable to enable IK
 				LOG_F(WARNING, "Unable to enable IK");
+				this->sendArmIKEnabledReport();
 			}
 		}
 	} else {

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -53,6 +53,7 @@ constexpr const char* LIDAR_REP_TYPE = "lidarReport";
 constexpr const char* MOUNTED_PERIPHERAL_REP_TYPE = "mountedPeripheralReport";
 constexpr const char* JOINT_POSITION_REP_TYPE = "jointPositionReport";
 constexpr const char* ROVER_POS_REP_TYPE = "roverPositionReport";
+constexpr const char* ARM_IK_ENABLED_REP_TYPE = "armIKEnabledReport";
 // TODO: add support for missing report types
 // autonomousPlannedPathReport, poseConfidenceReport
 
@@ -141,20 +142,24 @@ void MissionControlProtocol::handleRequestArmIKEnabled(const json& j) {
 		// TODO: there should be a better way of handling invalid data than crashing.
 		// It should somehow just not enable IK, but then it needs to communicate back to MC
 		// that IK wasn't enabled?
-		// FIX: Change setArmIKOn to requestArmIkOn.
-		// Create new packet: confirmIKOn packet
-		// Rover responds with confirmIKOn after requestArmIKOn is processed
-		assert(armJointPositions.isValid());
-		Globals::planarArmController.set_setpoint(armJointPositions.getData());
-		Globals::armIKEnabled = true;
-		_arm_ik_repeat_thread =
-			std::thread(&MissionControlProtocol::updateArmIKRepeatTask, this);
+		// FIX: Change setArmIKOn to requestArmIKEnable.
+		// Create new packet: armIKEnabledReport packet
+		// Rover responds with armIKEnabledReport after requestArmIKEnable is processed
+		// On Mission Control side, if armIKEnabledReport is false after trying to enable,
+		// give an alert stating that IK was unable to activated.
+		if (armJointPositions.isValid()) {
+			Globals::planarArmController.set_setpoint(armJointPositions.getData());
+			Globals::armIKEnabled = true;
+			_arm_ik_repeat_thread =
+				std::thread(&MissionControlProtocol::updateArmIKRepeatTask, this);
+		}
 	} else {
 		Globals::armIKEnabled = false;
 		if (_arm_ik_repeat_thread.joinable()) {
 			_arm_ik_repeat_thread.join();
 		}
 	}
+	sendArmIKEnabledReport(Globals::armIKEnabled);
 }
 
 void MissionControlProtocol::setRequestedCmdVel(double dtheta, double dx) {
@@ -256,6 +261,12 @@ void MissionControlProtocol::handleCameraStreamCloseRequest(const json& j) {
 	std::unique_lock<std::shared_mutex> stream_lock(this->_stream_mutex);
 	this->_open_streams.erase(cam);
 	this->_camera_encoders.erase(cam);
+}
+
+void MissionControlProtocol::sendArmIKEnabledReport() {
+	json msg = {{"type", ARM_IK_ENABLED_REP_TYPE},
+				{"enabled", Globals::armIKEnabled}};
+	this->_server.sendJSON(Constants::MC_PROTOCOL_NAME, msg);
 }
 
 void MissionControlProtocol::sendJointPositionReport(const std::string& jointName,

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -377,10 +377,6 @@ MissionControlProtocol::MissionControlProtocol(SingleClientWSServer& server)
 		std::bind(&MissionControlProtocol::handleRequestArmIKEnabled, this, _1),
 		validateArmIKEnable);
 	this->addMessageHandler(
-		ARM_IK_ENABLED_TYPE,
-		std::bind(&MissionControlProtocol::handleRequestArmIKEnabled, this, _1),
-		validateArmIKEnable);
-	this->addMessageHandler(
 		JOINT_POWER_REQ_TYPE,
 		std::bind(&MissionControlProtocol::handleJointPowerRequest, this, _1),
 		validateJointPowerRequest);

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -148,7 +148,7 @@ void MissionControlProtocol::handleRequestArmIKEnabled(const json& j) {
 			} else {
 				// unable to enable IK
 				LOG_F(WARNING, "Unable to enable IK");
-				this->sendArmIKEnabledReport();
+				this->setArmIKEnabled(false);
 			}
 		}
 	} else {

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -64,7 +64,7 @@ private:
 	void handleJointPowerRequest(const json& j);
 	void handleDriveRequest(const json& j);
 	void handleRequestArmIKEnabled(const json& j);
-	void sendArmIKEnabledReport(const bool& isEnabled);
+	void sendArmIKEnabledReport();
 	void sendCameraStreamReport(const CameraID& cam,
 								const std::vector<std::basic_string<uint8_t>>& videoData);
 	void sendJointPositionReport(const std::string& jointName, int32_t position);

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -72,7 +72,7 @@ private:
 	void handleConnection();
 	void handleHeartbeatTimedOut();
 	void startPowerRepeat();
-	void stopAndShutdownPowerRepeat();
+	void stopAndShutdownPowerRepeat(bool sendDisableIK);
 	void setArmIKEnabled(bool enabled);
 	void setRequestedJointPower(jointid_t joint, double power);
 	void setRequestedCmdVel(double dtheta, double dx);

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -64,6 +64,7 @@ private:
 	void handleJointPowerRequest(const json& j);
 	void handleDriveRequest(const json& j);
 	void handleRequestArmIKEnabled(const json& j);
+	void sendArmIKEnabledReport(const bool& isEnabled);
 	void sendCameraStreamReport(const CameraID& cam,
 								const std::vector<std::basic_string<uint8_t>>& videoData);
 	void sendJointPositionReport(const std::string& jointName, int32_t position);

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -63,7 +63,7 @@ private:
 	void handleCameraStreamCloseRequest(const json& j);
 	void handleJointPowerRequest(const json& j);
 	void handleDriveRequest(const json& j);
-	void handleSetArmIKEnabled(const json& j);
+	void handleRequestArmIKEnabled(const json& j);
 	void sendCameraStreamReport(const CameraID& cam,
 								const std::vector<std::basic_string<uint8_t>>& videoData);
 	void sendJointPositionReport(const std::string& jointName, int32_t position);

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -73,6 +73,7 @@ private:
 	void handleHeartbeatTimedOut();
 	void startPowerRepeat();
 	void stopAndShutdownPowerRepeat();
+	void setArmIKEnabled(const bool enabled);
 	void setRequestedJointPower(jointid_t joint, double power);
 	void setRequestedCmdVel(double dtheta, double dx);
 };

--- a/src/network/MissionControlProtocol.h
+++ b/src/network/MissionControlProtocol.h
@@ -73,7 +73,7 @@ private:
 	void handleHeartbeatTimedOut();
 	void startPowerRepeat();
 	void stopAndShutdownPowerRepeat();
-	void setArmIKEnabled(const bool enabled);
+	void setArmIKEnabled(bool enabled);
 	void setRequestedJointPower(jointid_t joint, double power);
 	void setRequestedCmdVel(double dtheta, double dx);
 };

--- a/src/network/websocket/WebSocketServer.h
+++ b/src/network/websocket/WebSocketServer.h
@@ -102,7 +102,7 @@ private:
 		// holds the periodically scheduled ping event and the watchdog
 		std::optional<std::pair<util::PeriodicScheduler<>::eventid_t, util::Watchdog<>>>
 			heartbeatInfo;
-		std::mutex mutex;
+		std::recursive_mutex mutex;
 	};
 
 	std::string serverName;

--- a/src/network/websocket/WebSocketServer.h
+++ b/src/network/websocket/WebSocketServer.h
@@ -102,7 +102,7 @@ private:
 		// holds the periodically scheduled ping event and the watchdog
 		std::optional<std::pair<util::PeriodicScheduler<>::eventid_t, util::Watchdog<>>>
 			heartbeatInfo;
-		std::recursive_mutex mutex;
+		std::mutex mutex;
 	};
 
 	std::string serverName;


### PR DESCRIPTION
Changes setArmIKEnabled packet to requestArmIKEnabled.
Adds reportArmIKEnabled packet
No longer crashes if enabling arm IK doesn't succeed. Instead it sends a new packet, reportArmIKEnabled which will let MC know if arm IK is enabled or not.