### PR TITLE
Represent rover orientation as quaternion instead of euler angles

### DIFF
--- a/src/ardupilot/ArduPilotInterface.cpp
+++ b/src/ardupilot/ArduPilotInterface.cpp
@@ -25,7 +25,7 @@ DataPoint<gpscoords_t> readGPSCoords() {
 } // namespace gps
 
 namespace robot {
-DataPoint<eulerangles_t> readIMU() {
+DataPoint<Eigen::Quaterniond> readIMU() {
 	return ardupilot_protocol->getIMU();
 }
 } // namespace robot

--- a/src/ardupilot/ArduPilotProtocol.cpp
+++ b/src/ardupilot/ArduPilotProtocol.cpp
@@ -4,6 +4,7 @@
 #include "../Globals.h"
 #include "../log.h"
 #include "../utils/json.h"
+#include "../utils/transform.h"
 
 #include <mutex>
 
@@ -82,7 +83,10 @@ void ArduPilotProtocol::handleIMURequest(const json& j) {
 	double roll = j["roll"];
 	double pitch = j["pitch"];
 	double yaw = j["yaw"];
-	_lastOrientation = eulerangles_t{roll, pitch, yaw};
+	eulerangles_t rpy{roll, pitch, yaw};
+
+	std::lock_guard lock(_lastOrientationMutex);
+	_lastOrientation = util::eulerAnglesToQuat(rpy);
 }
 
 bool ArduPilotProtocol::validateHeadingRequest(const json& j) {
@@ -91,6 +95,7 @@ bool ArduPilotProtocol::validateHeadingRequest(const json& j) {
 
 void ArduPilotProtocol::handleHeadingRequest(const json& j) {
 	int heading = j["heading"];
+	std::lock_guard lock(_lastHeadingMutex);
 	_lastHeading = heading;
 }
 
@@ -99,7 +104,7 @@ DataPoint<gpscoords_t> ArduPilotProtocol::getGPS() {
 	return _lastGPS;
 }
 
-DataPoint<eulerangles_t> ArduPilotProtocol::getIMU() {
+DataPoint<Eigen::Quaterniond> ArduPilotProtocol::getIMU() {
 	std::unique_lock<std::mutex> lock(_lastOrientationMutex);
 	return _lastOrientation;
 }

--- a/src/ardupilot/ArduPilotProtocol.h
+++ b/src/ardupilot/ArduPilotProtocol.h
@@ -6,6 +6,8 @@
 
 #include <mutex>
 
+#include <Eigen/Geometry>
+
 namespace net {
 namespace ardupilot {
 
@@ -23,11 +25,11 @@ public:
 	 */
 	robot::types::DataPoint<navtypes::gpscoords_t> getGPS();
 
-	/* @brief Gets the last reported IMU readings (roll, pitch, yaw)
+	/* @brief Gets the last reported orientation from the IMU
 	 *
-	 * @return Last reported IMU readings
+	 * @return Last reported orientation
 	 */
-	robot::types::DataPoint<navtypes::eulerangles_t> getIMU();
+	robot::types::DataPoint<Eigen::Quaterniond> getIMU();
 
 	/* @brief Gets the last reported heading (degrees)
 	 *
@@ -106,7 +108,7 @@ private:
 	robot::types::DataPoint<navtypes::gpscoords_t> _lastGPS;
 
 	std::mutex _lastOrientationMutex;
-	robot::types::DataPoint<navtypes::eulerangles_t> _lastOrientation;
+	robot::types::DataPoint<Eigen::Quaterniond> _lastOrientation;
 };
 
 } // namespace ardupilot

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -192,10 +192,7 @@ void MissionControlProtocol::sendRoverPos() {
 	log(LOG_DEBUG, "imu_valid=%s, gps_valid=%s\n", util::to_string(imu.isValid()).c_str(),
 		util::to_string(gps.isValid()).c_str());
 	if (imu.isValid()) {
-		auto rpy = imu.getData();
-		Eigen::Quaterniond quat(Eigen::AngleAxisd(rpy.roll, Eigen::Vector3d::UnitX()) *
-								Eigen::AngleAxisd(rpy.pitch, Eigen::Vector3d::UnitY()) *
-								Eigen::AngleAxisd(rpy.yaw, Eigen::Vector3d::UnitZ()));
+		Eigen::Quaterniond quat = imu.getData();
 		double lon = 0, lat = 0;
 		if (gps.isValid()) {
 			lon = gps.getData().lon;

--- a/src/utils/transform.cpp
+++ b/src/utils/transform.cpp
@@ -11,15 +11,21 @@ double quatToHeading(double qw, double qx, double qy, double qz) {
 	return quatToHeading(quat);
 }
 
-double quatToHeading(Eigen::Quaterniond quat) {
-	quat.normalize();
-	Eigen::Matrix3d rotMat = quat.toRotationMatrix();
+double quatToHeading(const Eigen::Quaterniond& quat) {
+	Eigen::Matrix3d rotMat = quat.normalized().toRotationMatrix();
 	Eigen::Vector3d transformedX = rotMat * Eigen::Vector3d::UnitX();
 	// flatten to xy-plane
 	transformedX(2) = 0;
 	// recover heading
 	double heading = std::atan2(transformedX(1), transformedX(0));
 	return heading;
+}
+
+Eigen::Quaterniond eulerAnglesToQuat(const navtypes::eulerangles_t& rpy) {
+	Eigen::Quaterniond quat(Eigen::AngleAxisd(rpy.roll, Eigen::Vector3d::UnitX()) *
+							Eigen::AngleAxisd(rpy.pitch, Eigen::Vector3d::UnitY()) *
+							Eigen::AngleAxisd(rpy.yaw, Eigen::Vector3d::UnitZ()));
+	return quat;
 }
 
 points_t transformReadings(const points_t& ps, const transform_t& tf) {
@@ -80,4 +86,4 @@ transform_t toTransform(const pose_t& pose) {
 	return toTransformRotateFirst(0, 0, pose(2)) * toTransformRotateFirst(pose(0), pose(1), 0);
 }
 
-}
+} // namespace util

--- a/src/utils/transform.h
+++ b/src/utils/transform.h
@@ -27,7 +27,15 @@ double quatToHeading(double qw, double qx, double qy, double qz);
  * @param quat The quaternion to extract the heading from. This does not need to be normalized.
  * @return double The CCW heading, in radians.
  */
-double quatToHeading(Eigen::Quaterniond quat);
+double quatToHeading(const Eigen::Quaterniond& quat);
+
+/**
+ * @brief Convert euler angles to a quaternion representation.
+ *
+ * @param rpy The euler angles to convert.
+ * @return Eigen::Quaterniond The same orientation represented as a quaternion.
+ */
+Eigen::Quaterniond eulerAnglesToQuat(const navtypes::eulerangles_t& rpy);
 
 /**
  * @brief Convert a set of points to a different reference frame.
@@ -123,4 +131,4 @@ double closestHeading(double theta, double prev_theta);
  */
 navtypes::transform_t toTransform(const navtypes::pose_t& pose);
 
-}
+} // namespace util

--- a/src/world_interface/gps_common_interface.cpp
+++ b/src/world_interface/gps_common_interface.cpp
@@ -1,4 +1,5 @@
 #include "../navtypes.h"
+#include "../utils/transform.h"
 #include "world_interface.h"
 
 #include <optional>
@@ -11,7 +12,8 @@ static std::optional<GPSToMetersConverter> converter;
 namespace robot {
 
 DataPoint<double> readIMUHeading() {
-	return readIMU().transform([](const navtypes::eulerangles_t& e) { return e.yaw; });
+	return readIMU().transform(
+		[](const Eigen::Quaterniond& q) { return util::quatToHeading(q); });
 }
 
 DataPoint<point_t> readGPS() {

--- a/src/world_interface/noop_world.cpp
+++ b/src/world_interface/noop_world.cpp
@@ -39,7 +39,7 @@ landmarks_t readLandmarks() {
 	return landmarks_t{};
 }
 
-DataPoint<navtypes::eulerangles_t> readIMU() {
+DataPoint<Eigen::Quaterniond> readIMU() {
 	return {};
 }
 

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -157,15 +157,11 @@ types::DataPoint<navtypes::point_t> readGPS();
 types::DataPoint<double> readIMUHeading();
 
 /**
- * @brief Read the rover attitude from the IMU.
+ * @brief Read the rover orientation from the IMU.
  *
- * Euler angles are in radians, in RPY format (i.e. XYZ extrinsic)
- *
- * @see https://en.wikipedia.org/wiki/Euler_angles#Tait%E2%80%93Bryan_angles
- *
- * @return types::DataPoint<navtypes::eulerangles_t>
+ * @return types::DataPoint<Eigen::Quaterniond>
  */
-types::DataPoint<navtypes::eulerangles_t> readIMU();
+types::DataPoint<Eigen::Quaterniond> readIMU();
 
 /**
  * @brief Get the ground truth pose, if available. This is only available in simulation.


### PR DESCRIPTION
Euler angles suck:
- they are ambiguous (granted, quaternions are a double-cover of SE3, but at least it's very easy to disambiguate, unlike euler angles)
- Euler angles are defined by 3 angles AND axis conventions, which will differ from code we may see in other places, and create hard-to-discover bugs, plus its hard to enforce. Quats don't have any additional associated conventions.
- Quaternions lend themselves more to linear algebra computations

The above reasons meant `readIMUHeading()` was wrong, since it wasn't giving the correct heading value, since the quat was being decomposed "incorrectly" into the euler angles. It was correct (technically), but wasn't what we wanted.

So this pr just represents rover orientation with quats instead of euler angles. And the heading is very easy to recover directly from the quat.