### PR TITLE
DiffDriveKinematics: Scale wheel velocity to stay below max speed

### DIFF
--- a/src/kinematics/DiffDriveKinematics.cpp
+++ b/src/kinematics/DiffDriveKinematics.cpp
@@ -55,15 +55,12 @@ pose_t DiffDriveKinematics::ensureWithinWheelSpeedLimit(
 	PreferredVelPreservation preferredVelPreservation, double xVel, double thetaVel,
 	double maxWheelSpeed) const {
 	auto [lVel, rVel] = robotVelToWheelVel(xVel, thetaVel);
-	double calculatedMaxWheelVel = std::max(abs(lVel), abs(rVel));
+	double calculatedMaxWheelVel = std::max(std::abs(lVel), std::abs(rVel));
 	if (calculatedMaxWheelVel > maxWheelSpeed) {
 		switch (preferredVelPreservation) {
 			case PreferredVelPreservation::Proportional: {
-				double maxAbsWheelVel = std::max(std::abs(lVel), std::abs(rVel));
-				if (maxAbsWheelVel > maxWheelSpeed) {
-					xVel *= maxWheelSpeed / maxAbsWheelVel;
-					thetaVel *= maxWheelSpeed / maxAbsWheelVel;
-				}
+				xVel *= maxWheelSpeed / calculatedMaxWheelVel;
+				thetaVel *= maxWheelSpeed / calculatedMaxWheelVel;
 			}
 			case PreferredVelPreservation::PreferXVel: {
 				if (std::abs(xVel) > maxWheelSpeed) {
@@ -88,7 +85,7 @@ pose_t DiffDriveKinematics::ensureWithinWheelSpeedLimit(
 				break;
 			}
 			case PreferredVelPreservation::PreferThetaVel: {
-				if (abs(wheelBaseWidth / 2 * thetaVel) > maxWheelSpeed) {
+				if (std::abs(wheelBaseWidth / 2 * thetaVel) > maxWheelSpeed) {
 					return {0, 0, std::copysign(maxWheelSpeed * 2 / wheelBaseWidth, thetaVel)};
 				}
 				if (std::max(lVel, rVel) > maxWheelSpeed) {

--- a/src/kinematics/DiffDriveKinematics.cpp
+++ b/src/kinematics/DiffDriveKinematics.cpp
@@ -2,7 +2,6 @@
 
 #include "../utils/transform.h"
 
-#include <cmath>
 using namespace navtypes;
 using util::toTransformRotateFirst;
 

--- a/src/kinematics/DiffDriveKinematics.cpp
+++ b/src/kinematics/DiffDriveKinematics.cpp
@@ -54,13 +54,14 @@ pose_t DiffDriveKinematics::getNextPose(const wheelvel_t& wheelVel, const pose_t
 pose_t DiffDriveKinematics::ensureWithinWheelSpeedLimit(
 	PreferredVelPreservation preferredVelPreservation, double xVel, double thetaVel,
 	double maxWheelSpeed) const {
-	auto [lVel, rVel] = robotVelToWheelVel(xVel, thetaVel);
-	double calculatedMaxWheelVel = std::max(std::abs(lVel), std::abs(rVel));
+	const auto [lVel, rVel] = robotVelToWheelVel(xVel, thetaVel);
+	const double calculatedMaxWheelVel = std::max(std::abs(lVel), std::abs(rVel));
 	if (calculatedMaxWheelVel > maxWheelSpeed) {
 		switch (preferredVelPreservation) {
 			case PreferredVelPreservation::Proportional: {
 				xVel *= maxWheelSpeed / calculatedMaxWheelVel;
 				thetaVel *= maxWheelSpeed / calculatedMaxWheelVel;
+				break;
 			}
 			case PreferredVelPreservation::PreferXVel: {
 				if (std::abs(xVel) > maxWheelSpeed) {

--- a/src/kinematics/DiffDriveKinematics.cpp
+++ b/src/kinematics/DiffDriveKinematics.cpp
@@ -1,10 +1,8 @@
 #include "DiffDriveKinematics.h"
 
-#include "../Constants.h"
 #include "../utils/transform.h"
 
 #include <cmath>
-#include <loguru.hpp>
 using namespace navtypes;
 using util::toTransformRotateFirst;
 
@@ -62,20 +60,14 @@ pose_t DiffDriveKinematics::ensureWithinWheelSpeedLimit(
 	if (calculatedMaxWheelVel > maxWheelSpeed) {
 		switch (preferredVelPreservation) {
 			case PreferredVelPreservation::Proportional: {
-				double lPWM = lVel / Constants::MAX_WHEEL_VEL;
-				double rPWM = rVel / Constants::MAX_WHEEL_VEL;
-				double maxAbsPWM = std::max(std::abs(lPWM), std::abs(rPWM));
-				if (maxAbsPWM > 1) {
-					lPWM /= maxAbsPWM;
-					rPWM /= maxAbsPWM;
+				double maxAbsWheelVel = std::max(std::abs(lVel), std::abs(rVel));
+				if (maxAbsWheelVel > maxWheelSpeed) {
+					xVel *= maxWheelSpeed / maxAbsWheelVel;
+					thetaVel *= maxWheelSpeed / maxAbsWheelVel;
 				}
-				auto newRobotVel = wheelVelToRobotVel(lPWM, rPWM);
-				xVel = newRobotVel.x();
-				thetaVel = newRobotVel.z();
-				break;
 			}
 			case PreferredVelPreservation::PreferXVel: {
-				if (abs(xVel) > maxWheelSpeed) {
+				if (std::abs(xVel) > maxWheelSpeed) {
 					return {std::copysign(maxWheelSpeed, xVel), 0, 0};
 				}
 				// Bring lVel up to -maxWheelSpeed

--- a/src/kinematics/DiffDriveKinematics.h
+++ b/src/kinematics/DiffDriveKinematics.h
@@ -78,6 +78,16 @@ public:
 	navtypes::pose_t getNextPose(const wheelvel_t& wheelVel, const navtypes::pose_t& pose,
 								 double dt) const;
 
+	enum PreferredVelPreservation {
+		Proportional,
+		PreferXVel,
+		PreferThetaVel,
+	};
+
+	navtypes::pose_t ensureWithinWheelSpeedLimit(PreferredVelPreservation preferred,
+												 double xVel, double thetaVel,
+												 double maxWheelSpeed) const;
+
 private:
 	double wheelBaseWidth;
 };

--- a/src/kinematics/DiffDriveKinematics.h
+++ b/src/kinematics/DiffDriveKinematics.h
@@ -14,8 +14,16 @@ struct wheelvel_t {
 class DiffDriveKinematics {
 public:
 	/**
-	 * Choose whether the velocity should be scaled proportionally, with respect to x velocity,
-	 * or with respect to theta velocity.
+	 * Proportional: The xVel and thetaVel are scaled an equal amount. This keeps the linear
+	 * and theta velocity at equal proportions to their original values but their output wheel
+	 * speed is below the max allowed.
+	 *
+	 * PreferXVel: The theta velocity is scaled and the x velocity is maintained. This
+	 * preserves linear velocity over theta velocity meaning we lose turning ability.
+	 *
+	 * PreferThetaVel: The x velocity is scaled and the theta velocity is maintained. This
+	 * preserves the ability to rotate the rover by scaling down the linear velocity so that
+	 * the calculated max wheel speed is below the set max wheel speed allowed.
 	 */
 	enum class PreferredVelPreservation {
 		Proportional,

--- a/src/kinematics/DiffDriveKinematics.h
+++ b/src/kinematics/DiffDriveKinematics.h
@@ -20,7 +20,7 @@ public:
 	enum class PreferredVelPreservation {
 		Proportional,
 		PreferXVel,
-		PreferThetaVel
+		PreferThetaVel,
 	};
 
 	/**

--- a/src/kinematics/DiffDriveKinematics.h
+++ b/src/kinematics/DiffDriveKinematics.h
@@ -20,7 +20,7 @@ public:
 	enum class PreferredVelPreservation {
 		Proportional,
 		PreferXVel,
-		PreferThetaVel,
+		PreferThetaVel
 	};
 
 	/**

--- a/src/kinematics/DiffDriveKinematics.h
+++ b/src/kinematics/DiffDriveKinematics.h
@@ -14,6 +14,16 @@ struct wheelvel_t {
 class DiffDriveKinematics {
 public:
 	/**
+	 * Choose whether the velocity should be scaled proportionally, with respect to x velocity,
+	 * or with respect to theta velocity.
+	 */
+	enum class PreferredVelPreservation {
+		Proportional,
+		PreferXVel,
+		PreferThetaVel,
+	};
+
+	/**
 	 * Create a new DiffDriveKinematics with the given wheel base width.
 	 *
 	 * @param wheelBaseWidth The width of the wheelbase. The units themselves don't matter, as
@@ -78,12 +88,18 @@ public:
 	navtypes::pose_t getNextPose(const wheelvel_t& wheelVel, const navtypes::pose_t& pose,
 								 double dt) const;
 
-	enum PreferredVelPreservation {
-		Proportional,
-		PreferXVel,
-		PreferThetaVel,
-	};
-
+	/**
+	 * Ensure that the given xVel and thetaVel translate to a wheel speed less than or equal
+	 * to the max wheel speed. Scales them if they do not.
+	 *
+	 * @param preferred Choose proportional if x velocity and theta velocity should be
+	 *                  scaled proportionally to each other, choose PreferXVel if linear
+	 * velocity is preferred, or choose PreferThetaVel if turning is preferred.
+	 * @param xVel The xVel used to calculate the wheel speed
+	 * @param thetaVel The theta veloicty used to calculate the wheel speed.
+	 * @param maxWheelSpeed The current max possible wheel speed. This is the value
+	 *                      that the calculated velocity will be checked against.
+	 */
 	navtypes::pose_t ensureWithinWheelSpeedLimit(PreferredVelPreservation preferred,
 												 double xVel, double thetaVel,
 												 double maxWheelSpeed) const;

--- a/src/world_interface/kinematic_common_interface.cpp
+++ b/src/world_interface/kinematic_common_interface.cpp
@@ -59,6 +59,11 @@ double setCmdVel(double dtheta, double dx) {
 		return 0;
 	}
 
+	navtypes::pose_t scaledVelocities = driveKinematics().ensureWithinWheelSpeedLimit(
+		DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel, dx, dtheta,
+		Constants::MAX_WHEEL_VEL);
+	dx = scaledVelocities.x();
+	dtheta = scaledVelocities.z();
 	wheelvel_t wheelVels = driveKinematics().robotVelToWheelVel(dx, dtheta);
 	double lPWM = wheelVels.lVel / Constants::MAX_WHEEL_VEL;
 	double rPWM = wheelVels.rVel / Constants::MAX_WHEEL_VEL;

--- a/src/world_interface/kinematic_common_interface.cpp
+++ b/src/world_interface/kinematic_common_interface.cpp
@@ -59,11 +59,6 @@ double setCmdVel(double dtheta, double dx) {
 		return 0;
 	}
 
-	navtypes::pose_t scaledVelocities = driveKinematics().ensureWithinWheelSpeedLimit(
-		DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel, dx, dtheta,
-		Constants::MAX_WHEEL_VEL);
-	dx = scaledVelocities.x();
-	dtheta = scaledVelocities.z();
 	wheelvel_t wheelVels = driveKinematics().robotVelToWheelVel(dx, dtheta);
 	double lPWM = wheelVels.lVel / Constants::MAX_WHEEL_VEL;
 	double rPWM = wheelVels.rVel / Constants::MAX_WHEEL_VEL;

--- a/tests/kinematics/DiffDriveKinematicsTest.cpp
+++ b/tests/kinematics/DiffDriveKinematicsTest.cpp
@@ -60,47 +60,49 @@ TEST_CASE("Differential Drive Kinematics Test") {
 	// Proportional Preservation Tests
 	assertApprox({0.5, 0, 0.5},
 				 kinematics.ensureWithinWheelSpeedLimit(
-					 kinematics::DiffDriveKinematics::PreferredVelPreservation::Proportional,
-					 1.0, 1.0, max_wheel_vel));
+					 DiffDriveKinematics::PreferredVelPreservation::Proportional, 1.0, 1.0,
+					 max_wheel_vel));
 
 	// xVel Preservation Tests
 	// Test #1: Test the xVel alone being too fast, therefore xVel should become the max and
-	// theta should
-	//          be zeroed
+	// theta should be zeroed
 	assertApprox({-max_wheel_vel, 0, 0},
 				 kinematics.ensureWithinWheelSpeedLimit(
-					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
-					 -1.0, 0.5, max_wheel_vel));
+					 DiffDriveKinematics::PreferredVelPreservation::PreferXVel, -1.0, 0.5,
+					 max_wheel_vel));
 	// Test #2: lVel < -max_wheel_vel
-	assertApprox({-0.4, 0, 0.7},
-				 kinematics.ensureWithinWheelSpeedLimit(
-					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
-					 -0.4, 1.6, max_wheel_vel));
+	assertApprox({-0.4, 0, 0.7}, kinematics.ensureWithinWheelSpeedLimit(
+									 DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
+									 -0.4, 1.6, max_wheel_vel));
 	// Test #3: lVel > max_wheel_vel: lVel = 1.0 rVel = 0.2
-	assertApprox({0.6, 0, -0.3},
-				 kinematics.ensureWithinWheelSpeedLimit(
-					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
-					 0.6, -0.5714, max_wheel_vel));
+	assertApprox({0.6, 0, -0.3}, kinematics.ensureWithinWheelSpeedLimit(
+									 DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
+									 0.6, -0.5714, max_wheel_vel));
 	// Test #4: rVel < -max_wheel_vel: lVel = 0.2 rVel = -0.9
 	assertApprox({-0.35, 0, -0.8},
 				 kinematics.ensureWithinWheelSpeedLimit(
-					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
-					 -0.35, -1.1, max_wheel_vel));
+					 DiffDriveKinematics::PreferredVelPreservation::PreferXVel, -0.35, -1.1,
+					 max_wheel_vel));
 	// Test #5: rVel > max_wheel_vel: lVel = 0.2 rVel = 0.9
-	assertApprox({0.55, 0, 0.4},
-				 kinematics.ensureWithinWheelSpeedLimit(
-					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
-					 0.55, 0.7, max_wheel_vel));
+	assertApprox({0.55, 0, 0.4}, kinematics.ensureWithinWheelSpeedLimit(
+									 DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
+									 0.55, 0.7, max_wheel_vel));
 
 	// thetaVel Preservation Tests
-	// Test #1: std::max(lVel, rVel) > maxWheelSpeed: lVel = 0.9 r_vel = 0.35
+	// Test #1: std::abs(wheelBaseWidth / 2 * thetaVel) > maxWheelSpeed - ie. thetaVel too big
+	// by itself
+	assertApprox({0, 0, 1.5},
+				 kinematics.ensureWithinWheelSpeedLimit(
+					 DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel, 0, 1.6,
+					 max_wheel_vel));
+	// Test #2: std::max(lVel, rVel) > maxWheelSpeed: lVel = 0.9 r_vel = 0.35
 	assertApprox({0.475, 0, -0.55},
 				 kinematics.ensureWithinWheelSpeedLimit(
-					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel,
-					 0.625, -0.55, max_wheel_vel));
-	// Test #2: std::min(lVel, rVel) < -maxWheelSpeed: lVel = -0.9 rVel = -0.2
+					 DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel, 0.625,
+					 -0.55, max_wheel_vel));
+	// Test #3: std::min(lVel, rVel) < -maxWheelSpeed: lVel = -0.9 rVel = -0.2
 	assertApprox({-0.4, 0, 0.7},
 				 kinematics.ensureWithinWheelSpeedLimit(
-					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel,
-					 -0.55, 0.7, max_wheel_vel));
+					 DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel, -0.55, 0.7,
+					 max_wheel_vel));
 }

--- a/tests/kinematics/DiffDriveKinematicsTest.cpp
+++ b/tests/kinematics/DiffDriveKinematicsTest.cpp
@@ -1,4 +1,6 @@
 #include "../../src/kinematics/DiffDriveKinematics.h"
+
+#include "../../src/Constants.h"
 #include "../../src/navtypes.h"
 
 #include <iostream>
@@ -60,4 +62,31 @@ TEST_CASE("Differential Drive Kinematics Test")
 	// drive CW in a full circle with radius 1
 	assertApprox({0, 0, 0},
 				 kinematics.getNextPose(wheelVel(3 * PI / 4, PI / 4), {0, 0, 0}, 4));
+
+	assertApprox({Constants::MAX_WHEEL_VEL, 0, 0},
+				 kinematics.ensureWithinWheelSpeedLimit(
+					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
+					 1.0, 1.0, Constants::MAX_WHEEL_VEL));
+	assertApprox({-Constants::MAX_WHEEL_VEL, 0, 0},
+				 kinematics.ensureWithinWheelSpeedLimit(
+					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
+					 -1.0, 0.5, Constants::MAX_WHEEL_VEL));
+	// FIXME: Make these tests actually check for all the possible cases of below/above min/max
+	// wheel speed.
+	assertApprox({0, 0, 0},
+				 kinematics.ensureWithinWheelSpeedLimit(
+					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
+					 0.5, 0.5, Constants::MAX_WHEEL_VEL));
+	assertApprox({0, 0, 0},
+				 kinematics.ensureWithinWheelSpeedLimit(
+					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
+					 0.5, 0.5, Constants::MAX_WHEEL_VEL));
+	assertApprox({0, 0, 0},
+				 kinematics.ensureWithinWheelSpeedLimit(
+					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel,
+					 0.5, 0.5, Constants::MAX_WHEEL_VEL));
+	assertApprox({0, 0, 0},
+				 kinematics.ensureWithinWheelSpeedLimit(
+					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel,
+					 0.5, 0.5, Constants::MAX_WHEEL_VEL));
 }

--- a/tests/kinematics/DiffDriveKinematicsTest.cpp
+++ b/tests/kinematics/DiffDriveKinematicsTest.cpp
@@ -93,12 +93,14 @@ TEST_CASE("Differential Drive Kinematics Test") {
 					 0.55, 0.7, max_wheel_vel));
 
 	// thetaVel Preservation Tests
-	assertApprox({0, 0, 0},
+	// Test #1: std::max(lVel, rVel) > maxWheelSpeed: lVel = 0.9 r_vel = 0.35
+	assertApprox({0.475, 0, -0.55},
 				 kinematics.ensureWithinWheelSpeedLimit(
 					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel,
-					 0.5, 0.5, max_wheel_vel));
-	assertApprox({0, 0, 0},
+					 0.625, -0.55, max_wheel_vel));
+	// Test #2: std::min(lVel, rVel) < -maxWheelSpeed: lVel = -0.9 rVel = -0.2
+	assertApprox({-0.4, 0, 0.7},
 				 kinematics.ensureWithinWheelSpeedLimit(
 					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferThetaVel,
-					 0.5, 0.5, max_wheel_vel));
+					 -0.55, 0.7, max_wheel_vel));
 }

--- a/tests/kinematics/DiffDriveKinematicsTest.cpp
+++ b/tests/kinematics/DiffDriveKinematicsTest.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Differential Drive Kinematics Test") {
 	assertApprox({0, 0, 0},
 				 kinematics.getNextPose(wheelVel(3 * PI / 4, PI / 4), {0, 0, 0}, 4));
 
-	double max_wheel_vel = 0.75;
+	constexpr double max_wheel_vel = 0.75;
 
 	// Proportional Preservation Tests
 	assertApprox({0.5, 0, 0.5},
@@ -64,18 +64,33 @@ TEST_CASE("Differential Drive Kinematics Test") {
 					 1.0, 1.0, max_wheel_vel));
 
 	// xVel Preservation Tests
+	// Test #1: Test the xVel alone being too fast, therefore xVel should become the max and
+	// theta should
+	//          be zeroed
 	assertApprox({-max_wheel_vel, 0, 0},
 				 kinematics.ensureWithinWheelSpeedLimit(
 					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
 					 -1.0, 0.5, max_wheel_vel));
-	assertApprox({0.5, 0, 0.5},
+	// Test #2: lVel < -max_wheel_vel
+	assertApprox({-0.4, 0, 0.7},
 				 kinematics.ensureWithinWheelSpeedLimit(
 					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
-					 0.5, 0.5, max_wheel_vel));
-	assertApprox({0, 0, 0},
+					 -0.4, 1.6, max_wheel_vel));
+	// Test #3: lVel > max_wheel_vel: lVel = 1.0 rVel = 0.2
+	assertApprox({0.6, 0, -0.3},
 				 kinematics.ensureWithinWheelSpeedLimit(
 					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
-					 0.5, 0.5, max_wheel_vel));
+					 0.6, -0.5714, max_wheel_vel));
+	// Test #4: rVel < -max_wheel_vel: lVel = 0.2 rVel = -0.9
+	assertApprox({-0.35, 0, -0.8},
+				 kinematics.ensureWithinWheelSpeedLimit(
+					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
+					 -0.35, -1.1, max_wheel_vel));
+	// Test #5: rVel > max_wheel_vel: lVel = 0.2 rVel = 0.9
+	assertApprox({0.55, 0, 0.4},
+				 kinematics.ensureWithinWheelSpeedLimit(
+					 kinematics::DiffDriveKinematics::PreferredVelPreservation::PreferXVel,
+					 0.55, 0.7, max_wheel_vel));
 
 	// thetaVel Preservation Tests
 	assertApprox({0, 0, 0},


### PR DESCRIPTION
Sometimes we want to scale the wheel velocity so that we focus more on rotational velocity or linear velocity. There are cases where the given theta velocity and linear velocity result in a wheel speed too great for the rover.