### PR TITLE
Don't repeatedly send packets commanding 0 power to drivebase

### DIFF
--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -434,7 +434,9 @@ void MissionControlProtocol::jointPowerRepeatTask() {
 				}
 			}
 			if (this->_last_cmd_vel) {
-				robot::setCmdVel(this->_last_cmd_vel->first, this->_last_cmd_vel->second);
+				if (this->_last_cmd_vel->first != 0.0 || this->_last_cmd_vel->second != 0.0) {
+					robot::setCmdVel(this->_last_cmd_vel->first, this->_last_cmd_vel->second);
+				}
 			}
 		}
 		_power_repeat_cv.wait_for(joint_repeat_lock, Constants::JOINT_POWER_REPEAT_PERIOD,


### PR DESCRIPTION
Minor improvement that only resends drivebase commands if they're nonzero. Note that this doesn't affect the first time it's sent, just the periodic resends.