### PR TITLE
Upgrade format checker CI to clang-format-18

### DIFF
--- a/.github/workflows/format-checker.yml
+++ b/.github/workflows/format-checker.yml
@@ -12,14 +12,16 @@ jobs:
         submodules: true
     - name: Install dependencies from APT
       run: |
-        sudo apt install -y git clang-format-11
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100 \
-          --slave /usr/share/man/man1/clang-format.1.gz clang-format.1.gz /usr/share/man/man1/clang-format-11.1.gz
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 18
+        sudo apt install -y git clang-format-18
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
     - name: Check Formatting
       run: |
         cd ${{ github.workspace }}
         git reset --soft $(git merge-base HEAD origin/master)
-        diff=$(git clang-format-11 --diff)
+        diff=$(git clang-format-18 --style=file --diff)
         if [ $(echo "${diff}" | wc -l) != 1 ]; then
           echo "Formatting errors detected! Suggested changes:" >&2
           echo "${diff}" >&2


### PR DESCRIPTION
We were previously using 11, which has a [bug](https://reviews.llvm.org/D106349) that was messing with our enums. Upgrading to 18 should fix this. 