### PR TITLE
Improve compiler warning flags

### DIFF
--- a/src/CAN/FakeCANBoard.cpp
+++ b/src/CAN/FakeCANBoard.cpp
@@ -20,7 +20,8 @@ using namespace std::chrono_literals;
 using can::motor::motormode_t;
 using namespace robot::types;
 
-enum class TestMode {
+enum class TestMode
+{
 	ModeSet,
 	PWM,
 	PID,
@@ -163,9 +164,11 @@ int main() {
 			[[maybe_unused]] double setPoint =
 				(targetVel * util::durationToSec(currTime - startTime)) +
 				initialMotorPos.getData();
+			LOG_F(INFO, "Set point: %f", setPoint);
 
 			// get y data: motor position
 			[[maybe_unused]] robot::types::DataPoint<int32_t> motorPos = motor->getMotorPos();
+			LOG_F(INFO, "Motor position: %d", motorPos.getData());
 
 			// check if time is up
 			double elapsedTime = util::durationToSec(currTime - startTime);

--- a/src/CAN/FakeCANBoard.cpp
+++ b/src/CAN/FakeCANBoard.cpp
@@ -20,8 +20,7 @@ using namespace std::chrono_literals;
 using can::motor::motormode_t;
 using namespace robot::types;
 
-enum class TestMode
-{
+enum class TestMode {
 	ModeSet,
 	PWM,
 	PID,

--- a/src/CAN/FakeCANBoard.cpp
+++ b/src/CAN/FakeCANBoard.cpp
@@ -160,13 +160,12 @@ int main() {
 			robot::types::datatime_t currTime = robot::types::dataclock::now();
 
 			// get y data: set point (target vel * time since set velocity call) + initial pos
-			[[maybe_unused]] double setPoint =
-				(targetVel * util::durationToSec(currTime - startTime)) +
-				initialMotorPos.getData();
+			double setPoint = (targetVel * util::durationToSec(currTime - startTime)) +
+							  initialMotorPos.getData();
 			LOG_F(INFO, "Set point: %f", setPoint);
 
 			// get y data: motor position
-			[[maybe_unused]] robot::types::DataPoint<int32_t> motorPos = motor->getMotorPos();
+			robot::types::DataPoint<int32_t> motorPos = motor->getMotorPos();
 			LOG_F(INFO, "Motor position: %d", motorPos.getData());
 
 			// check if time is up

--- a/src/CAN/FakeCANBoard.cpp
+++ b/src/CAN/FakeCANBoard.cpp
@@ -20,7 +20,8 @@ using namespace std::chrono_literals;
 using can::motor::motormode_t;
 using namespace robot::types;
 
-enum class TestMode {
+enum class TestMode
+{
 	ModeSet,
 	PWM,
 	PID,
@@ -160,11 +161,13 @@ int main() {
 			robot::types::datatime_t currTime = robot::types::dataclock::now();
 
 			// get y data: set point (target vel * time since set velocity call) + initial pos
-			double setPoint = (targetVel * util::durationToSec(currTime - startTime)) +
-							  initialMotorPos.getData();
+			__attribute__((unused)) double setPoint =
+				(targetVel * util::durationToSec(currTime - startTime)) +
+				initialMotorPos.getData();
 
 			// get y data: motor position
-			robot::types::DataPoint<int32_t> motorPos = motor->getMotorPos();
+			__attribute__((unused)) robot::types::DataPoint<int32_t> motorPos =
+				motor->getMotorPos();
 
 			// check if time is up
 			double elapsedTime = util::durationToSec(currTime - startTime);
@@ -224,7 +227,8 @@ int main() {
 					can::deviceid_t id = std::make_pair(can::devicegroup_t::motor, serial);
 					can::addDeviceTelemetryCallback(
 						id, can::telemtype_t::limit_switch,
-						[](can::deviceid_t id, can::telemtype_t telemType,
+						[](can::deviceid_t id,
+						   __attribute__((unused)) can::telemtype_t telemType,
 						   DataPoint<can::telemetry_t> data) {
 							std::cout << "Motor Limit: serial=" << std::hex
 									  << static_cast<int>(id.second)

--- a/src/CAN/FakeCANBoard.cpp
+++ b/src/CAN/FakeCANBoard.cpp
@@ -161,13 +161,12 @@ int main() {
 			robot::types::datatime_t currTime = robot::types::dataclock::now();
 
 			// get y data: set point (target vel * time since set velocity call) + initial pos
-			__attribute__((unused)) double setPoint =
+			[[maybe_unused]] double setPoint =
 				(targetVel * util::durationToSec(currTime - startTime)) +
 				initialMotorPos.getData();
 
 			// get y data: motor position
-			__attribute__((unused)) robot::types::DataPoint<int32_t> motorPos =
-				motor->getMotorPos();
+			[[maybe_unused]] robot::types::DataPoint<int32_t> motorPos = motor->getMotorPos();
 
 			// check if time is up
 			double elapsedTime = util::durationToSec(currTime - startTime);
@@ -227,8 +226,7 @@ int main() {
 					can::deviceid_t id = std::make_pair(can::devicegroup_t::motor, serial);
 					can::addDeviceTelemetryCallback(
 						id, can::telemtype_t::limit_switch,
-						[](can::deviceid_t id,
-						   __attribute__((unused)) can::telemtype_t telemType,
+						[](can::deviceid_t id, [[maybe_unused]] can::telemtype_t telemType,
 						   DataPoint<can::telemetry_t> data) {
 							std::cout << "Motor Limit: serial=" << std::hex
 									  << static_cast<int>(id.second)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -354,10 +354,10 @@ if (WORLD_INTERFACE STREQUAL "REAL")
 endif()
 
 add_compile_options(
+  -Wno-dev
   -Wall
   -Wextra
-  -Wconversion
-  -Wpedantic
+  # -Wconversion
 )
 
 add_subdirectory(ar)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -357,7 +357,7 @@ add_compile_options(
   -Wall
   -Wextra
   -Wno-deprecated-copy
-  -Werror
+  # -Werror
 )
 
 add_subdirectory(ar)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -356,7 +356,6 @@ endif()
 add_compile_options(
   -Wall
   -Wextra
-  -Wno-deprecated-copy
   -Werror
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -354,10 +354,10 @@ if (WORLD_INTERFACE STREQUAL "REAL")
 endif()
 
 add_compile_options(
-  -Wno-dev
   -Wall
   -Wextra
-  # -Wconversion
+  -Wno-deprecated-copy
+  -Werror
 )
 
 add_subdirectory(ar)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -357,7 +357,7 @@ add_compile_options(
   -Wall
   -Wextra
   -Wno-deprecated-copy
-  # -Werror
+  -Werror
 )
 
 add_subdirectory(ar)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,13 +126,6 @@ if(WORLD_INTERFACE STREQUAL "REAL")
   endif()
 endif()
 
-# Enable all warnings except a few (unused variable/parameter/result)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall \
--Wno-unused-variable \
--Wno-unused-but-set-variable \
--Wno-unused-result \
--Wno-unused-parameter") # -Wconversion")
-
 if(WITH_TESTS)
   enable_testing()
 endif()
@@ -359,6 +352,13 @@ if (WORLD_INTERFACE STREQUAL "REAL")
     LimitCalib.cpp)
   target_link_libraries(LimitSwitchCalibration real_world_interface)
 endif()
+
+add_compile_options(
+  -Wall
+  -Wextra
+  -Wconversion
+  -Wpedantic
+)
 
 add_subdirectory(ar)
 add_subdirectory(camera)

--- a/src/ar/ARTester.cpp
+++ b/src/ar/ARTester.cpp
@@ -1,6 +1,6 @@
 #include "../camera/Camera.h"
-#include "../camera/CameraParams.h"
 #include "../camera/CameraConfig.h"
+#include "../camera/CameraParams.h"
 #include "Detector.h"
 
 #include <chrono>
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) {
 	cam_config.release();
 
 	cv::Mat frame;
-	uint32_t fnum = 0;
+	__attribute__((unused)) uint32_t fnum = 0;
 
 	std::cout << "Opening camera..." << std::endl;
 	bool open_success = false;

--- a/src/ar/ARTester.cpp
+++ b/src/ar/ARTester.cpp
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) {
 	cam_config.release();
 
 	cv::Mat frame;
-	__attribute__((unused)) uint32_t fnum = 0;
+	[[maybe_unused]] uint32_t fnum = 0;
 
 	std::cout << "Opening camera..." << std::endl;
 	bool open_success = false;

--- a/src/camera/CameraParams.cpp
+++ b/src/camera/CameraParams.cpp
@@ -108,7 +108,7 @@ void read(const cv::FileNode& node, cam::CameraParams& params,
 	}
 }
 
-void write(cv::FileStorage& fs, __attribute__((unused)) const std::string& name,
+void write(cv::FileStorage& fs, [[maybe_unused]] const std::string& name,
 		   const cam::CameraParams& params) {
 	params.writeToFileStorage(fs);
 }

--- a/src/camera/CameraParams.cpp
+++ b/src/camera/CameraParams.cpp
@@ -1,17 +1,17 @@
 #include "CameraParams.h"
-#include "../../src/camera/CameraConfig.h"
 
 #include "../../src/Constants.h"
-#include <opencv2/core.hpp>
+#include "../../src/camera/CameraConfig.h"
 
 #include <vector>
+
+#include <opencv2/core.hpp>
 
 namespace cam {
 
 ////////////// CONSTRUCTORS //////////////
 
-CameraParams::CameraParams() {
-}
+CameraParams::CameraParams() {}
 
 void CameraParams::init(const cv::Mat& camera_matrix, const cv::Mat& dist_coeff,
 						cv::Size image_size) {
@@ -66,11 +66,11 @@ cv::Size CameraParams::getImageSize() const {
 	return _image_size;
 }
 
-std::vector<double> CameraParams::getIntrinsicList(){
+std::vector<double> CameraParams::getIntrinsicList() {
 	std::vector<double> intrinsic_list1D;
-	for (int i = 0; i < 3; i++){
-		for (int j = 0; j < 3; j++){
-			double x = _camera_matrix.at<double>(i,j);
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			double x = _camera_matrix.at<double>(i, j);
 			intrinsic_list1D.push_back(x);
 		}
 	}
@@ -99,7 +99,8 @@ void CameraParams::writeToFileStorage(cv::FileStorage& file_storage) const {
 	file_storage << "}";
 }
 
-void read(const cv::FileNode& node, cam::CameraParams& params, const cam::CameraParams& default_value) {
+void read(const cv::FileNode& node, cam::CameraParams& params,
+		  const cam::CameraParams& default_value) {
 	if (node.empty()) {
 		params = default_value;
 	} else {
@@ -107,7 +108,8 @@ void read(const cv::FileNode& node, cam::CameraParams& params, const cam::Camera
 	}
 }
 
-void write(cv::FileStorage& fs, const std::string& name, const cam::CameraParams& params) {
+void write(cv::FileStorage& fs, __attribute__((unused)) const std::string& name,
+		   const cam::CameraParams& params) {
 	params.writeToFileStorage(fs);
 }
 

--- a/src/camera/CameraParams.cpp
+++ b/src/camera/CameraParams.cpp
@@ -76,6 +76,16 @@ std::vector<double> CameraParams::getIntrinsicList() {
 	}
 	return intrinsic_list1D;
 }
+
+CameraParams& CameraParams::operator=(const CameraParams& other) {
+	if (this != &other) {
+		// Copy members from 'other' to 'this'
+		this->_camera_matrix = other._camera_matrix.clone();
+		this->_dist_coeff = other._dist_coeff.clone();
+		this->_image_size = other._image_size;
+	}
+	return *this;
+}
 ////////////// SERIALIZATION //////////////
 
 void CameraParams::readFromFileNode(const cv::FileNode& file_node) {

--- a/src/camera/CameraParams.h
+++ b/src/camera/CameraParams.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <opencv2/core.hpp>
 #include <vector>
+
+#include <opencv2/core.hpp>
 
 namespace cam {
 
@@ -112,6 +113,12 @@ public:
 	 @brief Gets the camera intrinsics as a 1d list.
 	*/
 	std::vector<double> getIntrinsicList();
+
+	/**
+	 @brief Define a copy assignment operator
+	 */
+	CameraParams& operator=(const CameraParams& other);
+
 	/**
 	   @brief Reads the data for this CameraParams object from the given cv::FileNode object.
 
@@ -147,6 +154,6 @@ void write(cv::FileStorage& fs, const std::string& name, const CameraParams& par
 
 /** @} */
 
-}
+} // namespace cam
 
 // namespace cam

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -228,8 +228,8 @@ static bool validateJointPositionRequest(const json& j) {
 static void handleJointPositionRequest(const json& j) {
 	// TODO: ignore this message if we are in autonomous mode.
 	std::string motor = j["joint"];
-	double position_deg = j["position"];
-	int32_t position_mdeg = std::round(position_deg * 1000);
+	__attribute__((unused)) double position_deg = j["position"];
+	__attribute__((unused)) int32_t position_mdeg = std::round(position_deg * 1000);
 	// TODO: actually implement joint position requests
 	// setMotorPos(motor, position_mdeg);
 }

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -225,11 +225,11 @@ static bool validateJointPositionRequest(const json& j) {
 	return validateJoint(j) && util::validateKey(j, "position", val_t::number_integer);
 }
 
-static void handleJointPositionRequest(const json& j) {
+static void handleJointPositionRequest([[maybe_unused]] const json& j) {
 	// TODO: ignore this message if we are in autonomous mode.
-	std::string motor = j["joint"];
-	[[maybe_unused]] double position_deg = j["position"];
-	[[maybe_unused]] int32_t position_mdeg = std::round(position_deg * 1000);
+	// std::string motor = j["joint"];
+	// [[maybe_unused]] double position_deg = j["position"];
+	// [[maybe_unused]] int32_t position_mdeg = std::round(position_deg * 1000);
 	// TODO: actually implement joint position requests
 	// setMotorPos(motor, position_mdeg);
 }

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -228,8 +228,8 @@ static bool validateJointPositionRequest(const json& j) {
 static void handleJointPositionRequest(const json& j) {
 	// TODO: ignore this message if we are in autonomous mode.
 	std::string motor = j["joint"];
-	__attribute__((unused)) double position_deg = j["position"];
-	__attribute__((unused)) int32_t position_mdeg = std::round(position_deg * 1000);
+	[[maybe_unused]] double position_deg = j["position"];
+	[[maybe_unused]] int32_t position_mdeg = std::round(position_deg * 1000);
 	// TODO: actually implement joint position requests
 	// setMotorPos(motor, position_mdeg);
 }

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -228,8 +228,8 @@ static bool validateJointPositionRequest(const json& j) {
 static void handleJointPositionRequest([[maybe_unused]] const json& j) {
 	// TODO: ignore this message if we are in autonomous mode.
 	// std::string motor = j["joint"];
-	// [[maybe_unused]] double position_deg = j["position"];
-	// [[maybe_unused]] int32_t position_mdeg = std::round(position_deg * 1000);
+	// double position_deg = j["position"];
+	// int32_t position_mdeg = std::round(position_deg * 1000);
 	// TODO: actually implement joint position requests
 	// setMotorPos(motor, position_mdeg);
 }


### PR DESCRIPTION
Right now, I've made this likely as verbose as we would possibly have it. It throws warnings for 
`-Wall
  -Wextra
  -Wconversion
  -Wpedantic`
See [here](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html).
  
Compile this and let me know which warnings make sense and which to suppress. Then, do we want to `-Werror` to really enforce these? This would require a lot of code cleanup to make our code compile without errors.