### PR TITLE
Fix format ci

### DIFF
--- a/.github/workflows/format-checker.yml
+++ b/.github/workflows/format-checker.yml
@@ -24,8 +24,8 @@ jobs:
         git reset --soft $(git merge-base HEAD origin/master)
         diff=$(git clang-format-18 --style=file --diff)
         if [ $(echo "${diff}" | wc -l) != 1 ]; then
-          echo "Formatting errors detected! Suggested changes:" >&2
-          echo "${diff}" >&2
+          echo "Formatting errors detected! Suggested changes:"
+          echo "${diff}"
           exit 1
         else
           echo "No formatting errors detected!"

--- a/.github/workflows/format-checker.yml
+++ b/.github/workflows/format-checker.yml
@@ -26,7 +26,7 @@ jobs:
         if [ $(echo "${diff}" | wc -l) != 1 ]; then
           echo "Formatting errors detected! Suggested changes:"
           echo "${diff}"
-          exit 1
+          exit 5
         else
           echo "No formatting errors detected!"
           exit 0

--- a/tests/util/SchedulerTest.cpp
+++ b/tests/util/SchedulerTest.cpp
@@ -133,7 +133,8 @@ TEST_CASE("Test Watchdog", "[util][scheduler]") {
 		REQUIRE(l->wait_for(10ms));
 
 		// check that callback is repeatedly called while starved
-		for (int i = 0; i < 3; i++) {
+		for (int i = 0; i < 3; i++)
+		{
 			l = std::make_shared<latch>(1);
 			advanceFakeClock(100ms, 5ms, wd);
 			REQUIRE(l->wait_for(10ms));


### PR DESCRIPTION
For some reason it seems like stderr wasn't being printed in the CI logs, so let's just print to stdout instead.