### PR TITLE
Handle IK failure gracefully

### DIFF
--- a/src/control/PlanarArmController.h
+++ b/src/control/PlanarArmController.h
@@ -126,10 +126,18 @@ public:
 		Eigen::Vector2d newPos = get_setpoint(currTime);
 		// lock after calling get_setpoint since that internally locks the mutex
 		std::lock_guard<std::mutex> lock(mutex);
-		setpoint = newPos;
 
 		// get new joint positions for target EE
-		return kin.eePosToJointPos(newPos, currJointPos);
+		bool success = false;
+		navtypes::Vectord<N> jp = kin.eePosToJointPos(newPos, currJointPos, success);
+		velTimestamp = currTime;
+		if (!success) {
+			LOG_F(WARNING, "IK Failure!");
+			velocity.setZero();
+		} else {
+			setpoint = newPos;
+		}
+		return jp;
 	}
 
 private:


### PR DESCRIPTION
Before, the velocity wouldn't get set to zero so the arm wouldn't move but the setpoint would keep moving at the current velocity. This PR ensure it gets handled properly, so the velocity is reset and the setpoint is made to be correct.