### PR TITLE
Remove heading messages from ArdupilotProtocol

### DIFF
--- a/src/ardupilot/ArduPilotProtocol.cpp
+++ b/src/ardupilot/ArduPilotProtocol.cpp
@@ -32,9 +32,6 @@ void ArduPilotProtocol::initArduPilotServer(SingleClientWSServer& websocketServe
 	ardupilot_protocol->addMessageHandler(
 		"orientation", std::bind(&ArduPilotProtocol::handleIMURequest, this, _1),
 		validateIMURequest);
-	ardupilot_protocol->addMessageHandler(
-		"heading", std::bind(&ArduPilotProtocol::handleHeadingRequest, this, _1),
-		validateHeadingRequest);
 	ardupilot_protocol->addConnectionHandler(
 		std::bind(&ArduPilotProtocol::clientConnected, this));
 	ardupilot_protocol->addDisconnectionHandler(
@@ -89,16 +86,6 @@ void ArduPilotProtocol::handleIMURequest(const json& j) {
 	_lastOrientation = util::eulerAnglesToQuat(rpy);
 }
 
-bool ArduPilotProtocol::validateHeadingRequest(const json& j) {
-	return util::validateKey(j, "heading", val_t::number_float);
-}
-
-void ArduPilotProtocol::handleHeadingRequest(const json& j) {
-	int heading = j["heading"];
-	std::lock_guard lock(_lastHeadingMutex);
-	_lastHeading = heading;
-}
-
 DataPoint<gpscoords_t> ArduPilotProtocol::getGPS() {
 	std::unique_lock<std::mutex> lock(_lastGPSMutex);
 	return _lastGPS;
@@ -107,11 +94,6 @@ DataPoint<gpscoords_t> ArduPilotProtocol::getGPS() {
 DataPoint<Eigen::Quaterniond> ArduPilotProtocol::getIMU() {
 	std::unique_lock<std::mutex> lock(_lastOrientationMutex);
 	return _lastOrientation;
-}
-
-DataPoint<int> ArduPilotProtocol::getHeading() {
-	std::unique_lock<std::mutex> lock(_lastHeadingMutex);
-	return _lastHeading;
 }
 
 bool ArduPilotProtocol::isArduPilotConnected() {

--- a/src/ardupilot/ArduPilotProtocol.h
+++ b/src/ardupilot/ArduPilotProtocol.h
@@ -31,12 +31,6 @@ public:
 	 */
 	robot::types::DataPoint<Eigen::Quaterniond> getIMU();
 
-	/* @brief Gets the last reported heading (degrees)
-	 *
-	 * @return Last reported heading
-	 */
-	robot::types::DataPoint<int> getHeading();
-
 private:
 	/* @brief Validates GPS request
 	 *
@@ -54,14 +48,6 @@ private:
 	 */
 	static bool validateIMURequest(const nlohmann::json& j);
 
-	/* @brief Validates heading request
-	 *
-	 * @param json message
-	 *
-	 * @return True if message is valid, false otherwise
-	 */
-	static bool validateHeadingRequest(const nlohmann::json& j);
-
 	/* @brief Destructures GPS json message and updates last reported GPS values
 	 *
 	 * @param json message
@@ -73,12 +59,6 @@ private:
 	 * @param json message
 	 */
 	void handleIMURequest(const nlohmann::json& j);
-
-	/* @brief Destructures heading json message and updates last reported GPS values
-	 *
-	 * @param json message
-	 */
-	void handleHeadingRequest(const nlohmann::json& j);
 
 	/* @brief Checks if the ArduPilotProtocol is connected
 	 *
@@ -100,9 +80,6 @@ private:
 
 	std::mutex _connectionMutex;
 	bool _arduPilotProtocolConnected;
-
-	std::mutex _lastHeadingMutex;
-	robot::types::DataPoint<int> _lastHeading;
 
 	std::mutex _lastGPSMutex;
 	robot::types::DataPoint<navtypes::gpscoords_t> _lastGPS;


### PR DESCRIPTION
Heading is encoded in the orientation, so no need for this.