### PR TITLE
Fix CMake circular dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,7 +190,7 @@ elseif(GPS STREQUAL "ARDUPILOT")
   target_sources(gps_interface PUBLIC
       ardupilot/ArduPilotProtocol.cpp
       ardupilot/ArduPilotInterface.cpp)
-  target_link_libraries(gps_interface utils websocket_utils rover_common)
+  target_link_libraries(gps_interface utils websocket_utils constants)
 else()
   target_sources(gps_interface PUBLIC gps/dummy/dummy_gps.cpp)
 endif()
@@ -199,7 +199,7 @@ endif()
 # hardware-agnostic utilities and common code for world interface
 add_library(world_interface_core STATIC
   world_interface/gps_common_interface.cpp
-  world_interface/kinematic_common_interface.cpp
+  # world_interface/kinematic_common_interface.cpp
   ar/Detector.cpp
   ar/MarkerSet.cpp
   ar/MarkerPattern.cpp
@@ -219,16 +219,24 @@ add_library(stub_world_interface STATIC
 add_library(real_world_interface STATIC
   world_interface/real_world_interface.cpp
   world_interface/motor/can_motor.cpp
-  Globals.cpp
-  )
+)
+
 add_library(simulator_interface STATIC
   world_interface/simulator_interface.cpp
   world_interface/motor/sim_motor.cpp
-  )
+)
 
 target_link_libraries(real_world_interface gps_interface can_interface world_interface_core)
 target_link_libraries(simulator_interface world_interface_core)
 target_link_libraries(stub_world_interface world_interface_core)
+
+if(WORLD_INTERFACE STREQUAL "REAL")
+  add_library(world_interface ALIAS real_world_interface)
+elseif(WORLD_INTERFACE STREQUAL "SIMULATOR")
+  add_library(world_interface ALIAS simulator_interface)
+else()
+  add_library(world_interface ALIAS stub_world_interface)
+endif()
 
 add_library(filters SHARED
   filters/StateSpaceUtil.cpp
@@ -255,24 +263,24 @@ add_library(commands SHARED
 
 add_library(autonomous SHARED
   autonomous/AutonomousTask.cpp)
-target_link_libraries(autonomous commands)
+target_link_libraries(autonomous commands world_interface)
 
-list(APPEND simulator_libs
-  simulator_interface)
+add_library(constants SHARED Constants.cpp)
 
 add_executable(Rover Rover.cpp)
 add_library(rover_common SHARED
-  Constants.cpp
   Globals.cpp
-  network/websocket/WebSocketServer.cpp
-  network/websocket/WebSocketProtocol.cpp
+  control_interface.cpp
   )
 target_link_libraries(rover_common
   utils
-  mission_control_interface)
+  websocket_utils
+  world_interface
+)
 
 list(APPEND rover_libs
   rover_common
+  constants
   Threads::Threads
   websocket_utils
   filters
@@ -281,23 +289,17 @@ list(APPEND rover_libs
   utils
 )
 target_link_libraries(Rover
-  ${rover_libs})
-
-if(WORLD_INTERFACE STREQUAL "REAL")
-  target_link_libraries(Rover real_world_interface)
-elseif(WORLD_INTERFACE STREQUAL "SIMULATOR")
-  target_link_libraries(Rover ${simulator_libs})
-else()
-  target_link_libraries(Rover real_world_interface) # TODO: support other interfaces
-endif()
-
-target_link_libraries(Rover ${vision_libs})
+  ${rover_libs}
+  mission_control_interface
+  world_interface
+  ${vision_libs}
+)
 
 add_executable(TunePID TunePID.cpp)
 target_link_libraries(TunePID
   ${rover_libs}
   can_interface
-  real_world_interface
+  world_interface
 )
 target_link_libraries(TunePID ${vision_libs})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,7 +190,7 @@ elseif(GPS STREQUAL "ARDUPILOT")
   target_sources(gps_interface PUBLIC
       ardupilot/ArduPilotProtocol.cpp
       ardupilot/ArduPilotInterface.cpp)
-  target_link_libraries(gps_interface utils websocket_utils constants)
+  target_link_libraries(gps_interface utils websocket_utils)
 else()
   target_sources(gps_interface PUBLIC gps/dummy/dummy_gps.cpp)
 endif()
@@ -199,7 +199,6 @@ endif()
 # hardware-agnostic utilities and common code for world interface
 add_library(world_interface_core STATIC
   world_interface/gps_common_interface.cpp
-  # world_interface/kinematic_common_interface.cpp
   ar/Detector.cpp
   ar/MarkerSet.cpp
   ar/MarkerPattern.cpp
@@ -266,6 +265,7 @@ add_library(autonomous SHARED
 target_link_libraries(autonomous commands world_interface)
 
 add_library(constants SHARED Constants.cpp)
+link_libraries(constants)
 
 add_executable(Rover Rover.cpp)
 add_library(rover_common SHARED
@@ -280,7 +280,6 @@ target_link_libraries(rover_common
 
 list(APPEND rover_libs
   rover_common
-  constants
   Threads::Threads
   websocket_utils
   filters

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -44,7 +44,6 @@ namespace Globals {
 RoverState curr_state;
 net::websocket::SingleClientWSServer websocketServer("DefaultServer",
 													 Constants::WS_SERVER_PORT);
-std::atomic<bool> E_STOP = false;
 std::atomic<bool> AUTONOMOUS = false;
 robot::types::mountedperipheral_t mountedPeripheral = robot::types::mountedperipheral_t::none;
 control::PlanarArmController<2> planarArmController(createArmKinematics(),

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -25,7 +25,6 @@ namespace Globals {
  */
 extern RoverState curr_state;
 extern net::websocket::SingleClientWSServer websocketServer;
-extern std::atomic<bool> E_STOP;
 extern std::atomic<bool> AUTONOMOUS;
 extern robot::types::mountedperipheral_t mountedPeripheral;
 extern control::PlanarArmController<2> planarArmController;

--- a/src/LimitCalib.cpp
+++ b/src/LimitCalib.cpp
@@ -34,7 +34,7 @@ void cleanup(int signum) {
 // Then begins to run the motors.
 int main() {
 	// init motors.
-	robot::world_interface_init(true);
+	robot::world_interface_init(std::nullopt, true);
 
 	signal(SIGINT, cleanup);
 

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -26,7 +26,7 @@ using std::chrono::steady_clock;
 using namespace navtypes;
 using namespace robot::types;
 
-void closeRover(int signum) {
+void closeRover(int) {
 	robot::emergencyStop();
 	Globals::websocketServer.stop();
 	raise(SIGTERM);

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -149,7 +149,7 @@ int main(int argc, char** argv) {
 	parseCommandLine(argc, argv);
 	Globals::AUTONOMOUS = false;
 	Globals::websocketServer.start();
-	robot::world_interface_init();
+	robot::world_interface_init(Globals::websocketServer);
 	auto mcProto = std::make_unique<net::mc::MissionControlProtocol>(Globals::websocketServer);
 	Globals::websocketServer.addProtocol(std::move(mcProto));
 	// Ctrl+C doesn't stop the simulation without this line

--- a/src/TunePID.cpp
+++ b/src/TunePID.cpp
@@ -55,7 +55,7 @@ void cleanup(int signum) {
 }
 
 int main(int argc, char** argv) {
-	robot::world_interface_init();
+	robot::world_interface_init(std::nullopt);
 
 	// TODO: Before running this script, make sure the PPJR is set correctly for each motor
 	// in real_world_constants.cpp

--- a/src/ardupilot/ArduPilotProtocol.cpp
+++ b/src/ardupilot/ArduPilotProtocol.cpp
@@ -1,7 +1,6 @@
 #include "ArduPilotProtocol.h"
 
 #include "../Constants.h"
-#include "../Globals.h"
 #include "../utils/json.h"
 #include "../utils/transform.h"
 

--- a/src/autonomous/AutonomousTask.cpp
+++ b/src/autonomous/AutonomousTask.cpp
@@ -2,6 +2,7 @@
 
 #include "../Constants.h"
 #include "../commands/DriveToWaypointCommand.h"
+#include "../control_interface.h"
 #include "../utils/transform.h"
 #include "../world_interface/world_interface.h"
 

--- a/src/control_interface.cpp
+++ b/src/control_interface.cpp
@@ -1,9 +1,11 @@
-#include "../Constants.h"
-#include "../Globals.h"
-#include "../kinematics/DiffDriveKinematics.h"
-#include "../navtypes.h"
-#include "../utils/transform.h"
-#include "world_interface.h"
+#include "control_interface.h"
+
+#include "Constants.h"
+#include "Globals.h"
+#include "kinematics/DiffDriveKinematics.h"
+#include "navtypes.h"
+#include "utils/transform.h"
+#include "world_interface/world_interface.h"
 
 #include <atomic>
 #include <chrono>

--- a/src/control_interface.h
+++ b/src/control_interface.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "world_interface/data.h"
+
+// This is a layer that provides further abstraction on top of
+// the motor-level control provided by the world interface
+
+namespace robot {
+
+/**
+ * @brief Request the robot to drive at the given velocities.
+ *
+ * @param dtheta The heading velocity.
+ * @param dx The forward velocity.
+ * @return double If the requested velocities are too high, they will be scaled down.
+ * The returned value is the scale divisor. If no scaling was performed, 1 is returned.
+ */
+double setCmdVel(double dtheta, double dx);
+
+/**
+ * @brief Set the power of the specified joint.
+ *
+ * @param joint The joint to set the power of.
+ * @param power The power value to set, in the range [-1,1].
+ */
+void setJointPower(types::jointid_t joint, double power);
+
+/**
+ * @brief Set the position of the specified joint.
+ *
+ * @param joint the jointid_t of the joint to set the position of.
+ * @param targetPos the position to set the joint to, in millidegrees.
+ */
+void setJointPos(types::jointid_t joint, int32_t pos);
+
+/**
+ * @param joint the jointid_t of the joint to get the position of.
+ * @return the position of the joint specified by the jointid_t argument joint,
+ * in millidegrees.
+ */
+types::DataPoint<int32_t> getJointPos(types::jointid_t joint);
+
+} // namespace robot

--- a/src/control_interface.h
+++ b/src/control_interface.h
@@ -31,7 +31,7 @@ void setJointPower(types::jointid_t joint, double power);
  * @param joint the jointid_t of the joint to set the position of.
  * @param targetPos the position to set the joint to, in millidegrees.
  */
-void setJointPos(types::jointid_t joint, int32_t pos);
+void setJointPos(types::jointid_t joint, int32_t targetPos);
 
 /**
  * @param joint the jointid_t of the joint to get the position of.

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -3,6 +3,7 @@
 #include "../Constants.h"
 #include "../Globals.h"
 #include "../autonomous/AutonomousTask.h"
+#include "../control_interface.h"
 #include "../utils/core.h"
 #include "../utils/json.h"
 #include "../world_interface/data.h"

--- a/src/network/MissionControlProtocol.cpp
+++ b/src/network/MissionControlProtocol.cpp
@@ -56,7 +56,6 @@ void MissionControlProtocol::handleEmergencyStopRequest(const json& j) {
 		_power_repeat_task.start();
 	}
 	// TODO: reinit motors
-	Globals::E_STOP = stop;
 	this->setArmIKEnabled(false);
 }
 
@@ -245,7 +244,6 @@ void MissionControlProtocol::handleHeartbeatTimedOut() {
 	LOG_F(ERROR, "Heartbeat timed out! Emergency stopping.");
 	this->stopAndShutdownPowerRepeat(true);
 	robot::emergencyStop();
-	Globals::E_STOP = true;
 }
 
 void MissionControlProtocol::stopAndShutdownPowerRepeat(bool sendDisableIK) {

--- a/src/network/MissionControlTasks.cpp
+++ b/src/network/MissionControlTasks.cpp
@@ -2,6 +2,7 @@
 
 #include "../Constants.h"
 #include "../Globals.h"
+#include "../control_interface.h"
 #include "../utils/core.h"
 #include "../world_interface/world_interface.h"
 #include "MissionControlMessages.h"

--- a/src/world_interface/kinematic_common_interface.cpp
+++ b/src/world_interface/kinematic_common_interface.cpp
@@ -32,7 +32,7 @@ double getJointPowerValue(types::jointid_t joint);
 } // namespace
 
 double setCmdVel(double dtheta, double dx) {
-	if (Globals::E_STOP && (dtheta != 0 || dx != 0)) {
+	if (isEmergencyStopped()) {
 		return 0;
 	}
 

--- a/src/world_interface/noop_world.cpp
+++ b/src/world_interface/noop_world.cpp
@@ -27,7 +27,9 @@ const DiffWristKinematics& wristKinematics() {
 	return wrist_kinematics;
 }
 
-void world_interface_init(bool initMotorsOnly) {}
+void world_interface_init(
+	std::optional<std::reference_wrapper<net::websocket::SingleClientWSServer>> wsServer,
+	bool initMotorsOnly) {}
 
 std::shared_ptr<robot::base_motor> getMotor(robot::types::motorid_t motor) {
 	return nullptr;

--- a/src/world_interface/noop_world.cpp
+++ b/src/world_interface/noop_world.cpp
@@ -35,6 +35,10 @@ std::shared_ptr<robot::base_motor> getMotor(robot::types::motorid_t motor) {
 
 void emergencyStop() {}
 
+bool isEmergencyStopped() {
+	return false;
+}
+
 landmarks_t readLandmarks() {
 	return landmarks_t{};
 }

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -35,6 +35,7 @@ std::unordered_map<robot::types::motorid_t, std::shared_ptr<robot::base_motor>> 
 namespace {
 kinematics::DiffDriveKinematics drive_kinematics(Constants::EFF_WHEEL_BASE);
 kinematics::DiffWristKinematics wrist_kinematics;
+bool is_emergency_stopped = false;
 
 void addMotorMapping(motorid_t motor, bool hasPosSensor) {
 	// get scales for motor
@@ -157,6 +158,11 @@ std::shared_ptr<robot::base_motor> getMotor(robot::types::motorid_t motor) {
 
 void emergencyStop() {
 	can::motor::emergencyStopMotors();
+	is_emergency_stopped = true;
+}
+
+bool isEmergencyStopped() {
+	return is_emergency_stopped;
 }
 
 std::unordered_set<CameraID> getCameras() {

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -2,7 +2,6 @@
 #include "../CAN/CANMotor.h"
 #include "../CAN/CANUtils.h"
 #include "../Constants.h"
-#include "../Globals.h"
 #include "../ardupilot/ArduPilotInterface.h"
 #include "../camera/Camera.h"
 #include "../gps/usb_gps/read_usb_gps.h"
@@ -134,10 +133,14 @@ void setupCameras() {
 }
 } // namespace
 
-void world_interface_init(bool initOnlyMotors) {
+void world_interface_init(
+	std::optional<std::reference_wrapper<net::websocket::SingleClientWSServer>> wsServer,
+	bool initOnlyMotors) {
 	if (!initOnlyMotors) {
 		setupCameras();
-		ardupilot::initArduPilotProtocol(Globals::websocketServer);
+		if (wsServer.has_value()) {
+			ardupilot::initArduPilotProtocol(wsServer.value());
+		}
 	}
 	can::initCAN();
 	initMotors();

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -54,6 +54,8 @@ std::mutex truePoseMutex;
 std::map<std::string, DataPoint<int32_t>> motorPosMap;
 std::shared_mutex motorPosMapMutex;
 
+bool is_emergency_stopped = false;
+
 // A mapping of (motor_id, shared pointer to object of the motor)
 std::unordered_map<robot::types::motorid_t, std::shared_ptr<robot::base_motor>> motor_ptrs;
 
@@ -278,6 +280,11 @@ void emergencyStop() {
 	for (const auto& motor : motorNameMap) {
 		setMotorPower(motor.first, 0.0);
 	}
+	is_emergency_stopped = true;
+}
+
+bool isEmergencyStopped() {
+	return is_emergency_stopped;
 }
 
 std::unordered_set<CameraID> getCameras() {

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -62,6 +62,13 @@ std::shared_ptr<robot::base_motor> getMotor(robot::types::motorid_t motor);
 void emergencyStop();
 
 /**
+ * @brief Check if the robot has been emergency stopped.
+ *
+ * @return If emergencyStop() has been called previously.
+ */
+bool isEmergencyStopped();
+
+/**
  * @brief Request the robot to drive at the given velocities.
  *
  * @param dtheta The heading velocity.

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -47,7 +47,8 @@ const kinematics::DiffWristKinematics& wristKinematics();
  *
  * @param wsServer A reference to the websocket server to use for communication.
  * If empty, components that require it will not be initialized.
- * @param initOnlyMotors If true, only initialize the motors and not the rest of the world interface.
+ * @param initOnlyMotors If true, only initialize the motors and not the rest of the world
+ * interface.
  */
 void world_interface_init(
 	std::optional<std::reference_wrapper<net::websocket::SingleClientWSServer>> wsServer,

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -4,6 +4,7 @@
 #include "../kinematics/DiffDriveKinematics.h"
 #include "../kinematics/DiffWristKinematics.h"
 #include "../navtypes.h"
+#include "../network/websocket/WebSocketServer.h"
 #include "data.h"
 #include "motor/base_motor.h"
 
@@ -43,8 +44,14 @@ const kinematics::DiffWristKinematics& wristKinematics();
  *
  * This method should only be called once, and must be called
  * before any other world interface methods.
+ *
+ * @param wsServer A reference to the websocket server to use for communication.
+ * If empty, components that require it will not be initialized.
+ * @param initOnlyMotors If true, only initialize the motors and not the rest of the world interface.
  */
-void world_interface_init(bool initOnlyMotors = false);
+void world_interface_init(
+	std::optional<std::reference_wrapper<net::websocket::SingleClientWSServer>> wsServer,
+	bool initOnlyMotors = false);
 
 /**
  * @brief Get a pointer to the motor object associated with the motor id.
@@ -67,16 +74,6 @@ void emergencyStop();
  * @return If emergencyStop() has been called previously.
  */
 bool isEmergencyStopped();
-
-/**
- * @brief Request the robot to drive at the given velocities.
- *
- * @param dtheta The heading velocity.
- * @param dx The forward velocity.
- * @return double If the requested velocities are too high, they will be scaled down.
- * The returned value is the scale divisor. If no scaling was performed, 1 is returned.
- */
-double setCmdVel(double dtheta, double dx);
 
 /**
  * @brief Get the IDs of the currently supported cameras.
@@ -230,22 +227,6 @@ callbackid_t addLimitSwitchCallback(
 		robot::types::DataPoint<robot::types::LimitSwitchData> limitSwitchData)>& callback);
 
 void removeLimitSwitchCallback(callbackid_t id);
-
-// TODO: document
-void setJointPower(robot::types::jointid_t joint, double power);
-
-/**
- * @param joint, the jointid_t of the joint to set the position of.
- * @param targetPos, the position to set the joint to, in millidegrees.
- */
-void setJointPos(robot::types::jointid_t joint, int32_t targetPos);
-
-/**
- * @param joint, the jointid_t of the joint to get the position of.
- * @return the position of the joint specified by the jointid_t argument joint,
- * in millidegrees.
- */
-types::DataPoint<int32_t> getJointPos(robot::types::jointid_t joint);
 
 /**
  * @brief Get the positions in radians of multiple motors at the same time.


### PR DESCRIPTION
Our CMake is becoming a bit of a mess, and circular dependencies were cropping up. This PR doesn't fully fix this problem, but is a partial solution. This PR focuses on the use of shared global state, particularly `Globals.h`, which had become way too pervasive in our codebase.
 - Moved E-Stop from globals to instead be owned by the world interface (which also makes more sense, since we should refuse to move motors if e-stopped) NOTE: there actually isn't code that checks for this, so that should be done in a follow-up PR
 - Moved `kinematic_common_interface` out of the world interface layer. It has been renamed to `control_interface`, and is not part of the world interface, it is only an abstraction around it.
 - Some refactoring to remove dependencies on global state, including creating a separate `constants` build target for use.

Overall, we need to focus on the distinction between "application code" and "library code". Library code should be the core functionality and modules of our codebase, which is instrumented and used by the application code. In general, library code should **not** use shared global state, while application code can.