### PR TITLE
Update configurations for new jetson orin nx

### DIFF
--- a/enable_CAN.sh
+++ b/enable_CAN.sh
@@ -1,21 +1,16 @@
 #!/bin/bash
 
 CAN_BITRATE="${CAN_BITRATE:-125000}"
-CAN_DBITRATE="${CAN_DBITRATE:-500000}"
+CAN_DBITRATE="${CAN_DBITRATE:-125000}"
 
 sudo modprobe can
 sudo modprobe can_raw
 sudo modprobe mttcan
 
 sudo ip link set can0 type can bitrate "${CAN_BITRATE}" dbitrate "${CAN_DBITRATE}" \
-     berr-reporting on fd on
-sudo ip link set can1 type can bitrate "${CAN_BITRATE}" dbitrate "${CAN_DBITRATE}" \
-     berr-reporting on fd on
+     berr-reporting on fd on restart-ms 100
 sudo ip link set up can0
-sudo ip link set up can1
 
 if [[ $? != 0 ]]; then
-  echo "Could not enable hardware CAN interface; using virtual CAN instead."
-  sudo ip link add type vcan
-  sudo ip link set dev vcan0 up
+  echo "Error enabling can0 interface!"
 fi

--- a/enable_CAN_and_GPS.sh
+++ b/enable_CAN_and_GPS.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CAN_BITRATE=125000
-CAN_DBITRATE=500000
+CAN_DBITRATE=125000
 GPS_PATH="/dev/ttyUSB0"
 
 sudo modprobe can
@@ -9,16 +9,11 @@ sudo modprobe can_raw
 sudo modprobe mttcan
 
 sudo ip link set can0 type can bitrate "${CAN_BITRATE}" dbitrate "${CAN_DBITRATE}" \
-     berr-reporting on fd on
-sudo ip link set can1 type can bitrate "${CAN_BITRATE}" dbitrate "${CAN_DBITRATE}" \
-     berr-reporting on fd on
+     berr-reporting on fd on restart-ms 100
 sudo ip link set up can0
-sudo ip link set up can1
 
 if [[ $? != 0 ]]; then
-  echo "Could not enable hardware CAN interface; using virtual CAN instead."
-  sudo ip link add type vcan
-  sudo ip link set dev vcan0 up
+  echo "Error enabling can0 interface!"
 fi
 
 # For some reason, on the rover, the gpsd that starts on boot does not

--- a/rover-config/50-rover-cameras.rules
+++ b/rover-config/50-rover-cameras.rules
@@ -7,10 +7,10 @@
 # Install this in /etc/udev/rules.d
 
 # Hand camera
-SUBSYSTEM=="video4linux", ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="6369", KERNELS=="1-2.1", SYMLINK+="video20"
+SUBSYSTEM=="video4linux", ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="6369", ATTR{index}=="0", SYMLINK+="video20"
 
 # Forearm camera
-SUBSYSTEM=="video4linux", ATTRS{idVendor}=="32e4", ATTRS{idProduct}=="9230", KERNELS=="1-2.1", SYMLINK+="video30"
+SUBSYSTEM=="video4linux", ATTRS{idVendor}=="32e4", ATTRS{idProduct}=="9230", ATTR{index}=="0", SYMLINK+="video30"
 
 # Mast camera
-SUBSYSTEM=="video4linux", ATTRS{idVendor}=="05a3", ATTRS{idProduct}=="9230", KERNELS=="1-2.4.4", SYMLINK+="video40"
+SUBSYSTEM=="video4linux", ATTRS{idVendor}=="05a3", ATTRS{idProduct}=="9230", ATTR{index}=="0", SYMLINK+="video40"

--- a/src/CAN/CAN.cpp
+++ b/src/CAN/CAN.cpp
@@ -264,13 +264,16 @@ void initCAN() {
 }
 
 void sendCANPacket(const CANPacket& packet) {
-	can_frame frame;
+	canfd_frame frame;
+	std::memset(&frame, 0, sizeof(frame));
 	frame.can_id = packet.id;
-	frame.can_dlc = packet.dlc;
+	frame.len = packet.dlc;
 	std::memcpy(frame.data, packet.data, packet.dlc);
 	bool success;
 	{
 		std::lock_guard lock(socketMutex);
+		// note that frame is a canfd_frame but we're using sizeof(can_frame)
+		// not sure why this is required to work
 		success = write(can_fd, &frame, sizeof(struct can_frame)) == sizeof(struct can_frame);
 		tcdrain(can_fd);
 	}

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -113,6 +113,7 @@ void openCamera(CameraID camID, const char* cameraPath) {
 
 void setupCameras() {
 	openCamera(Constants::MAST_CAMERA_ID, Constants::MAST_CAMERA_CONFIG_PATH);
+	openCamera(Constants::FOREARM_CAMERA_ID, Constants::FOREARM_CAMERA_CONFIG_PATH);
 	openCamera(Constants::HAND_CAMERA_ID, Constants::HAND_CAMERA_CONFIG_PATH);
 }
 } // namespace


### PR DESCRIPTION
Reconfigure CAN to have the right datarate, update the CAN code to use can FD frames, update the camera udev rules to match the real camera device instead of the virtual metadata device (due to new video4linux kernel)